### PR TITLE
feat: add DeepLX translation provider support

### DIFF
--- a/capcap/Settings/TranslationSettingsPane.swift
+++ b/capcap/Settings/TranslationSettingsPane.swift
@@ -289,7 +289,7 @@ private final class TranslationProviderCard: NSView {
         body.addArrangedSubview(makeFieldRow(apiKeyLabel, apiKeyField,
                                              label: L10n.translationApiKey,
                                              placeholder: "sk-…", width: body))
-        if !kind.isDeepL {
+        if !kind.isDirectTranslationAPI {
             body.addArrangedSubview(makeFieldRow(modelLabel, modelField,
                                                  label: L10n.translationModel,
                                                  placeholder: modelPlaceholder(), width: body))
@@ -373,6 +373,9 @@ private final class TranslationProviderCard: NSView {
         if kind.isDeepL {
             return "Auto: api-free.deepl.com for :fx keys"
         }
+        if kind.isDeepLX {
+            return kind.defaultEndpoint
+        }
         return kind.defaultEndpoint.isEmpty
             ? "https://api.example.com/v1/chat/completions"
             : kind.defaultEndpoint
@@ -390,7 +393,7 @@ private final class TranslationProviderCard: NSView {
     private func currentConfig() -> TranslationConfig {
         TranslationConfig(
             apiKey: apiKeyField.stringValue,
-            model: kind.isDeepL ? "" : modelField.stringValue,
+            model: kind.isDirectTranslationAPI ? "" : modelField.stringValue,
             endpoint: endpointField.stringValue
         )
     }

--- a/capcap/Settings/TranslationSettingsPane.swift
+++ b/capcap/Settings/TranslationSettingsPane.swift
@@ -474,9 +474,11 @@ private final class TranslationProviderCard: NSView {
         TranslationConfigStore.save(config, for: kind)
 
         // Nothing to test against without an API key — just confirm the save.
-        guard !config.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            flashButton(saveButton, to: L10n.translationConfigSaved, restore: L10n.translationSave)
-            return
+        if kind.isAPIKeyRequired {
+            guard !config.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                flashButton(saveButton, to: L10n.translationConfigSaved, restore: L10n.translationSave)
+                return
+            }
         }
 
         saveButton.isEnabled = false

--- a/capcap/Translation/OCRTranslatePanel.swift
+++ b/capcap/Translation/OCRTranslatePanel.swift
@@ -1112,7 +1112,7 @@ final class OCRTranslatePanel: NSPanel {
         currentDictionaryProvider = nil
         showDictionaryHeader(word: word)
 
-        guard let kind = TranslationConfigStore.usableKinds().first(where: { !$0.isDeepL }) else {
+        guard let kind = TranslationConfigStore.usableKinds().first(where: { !$0.isDirectTranslationAPI }) else {
             setTranslationPlaceholder("\(L10n.dictionaryNoProviderTitle)\n\(L10n.dictionaryNoProviderHint)")
             refreshHeight()
             return

--- a/capcap/Translation/TranslationProvider.swift
+++ b/capcap/Translation/TranslationProvider.swift
@@ -103,11 +103,12 @@ enum TranslationLanguage: String, CaseIterable {
 // MARK: - Provider kinds
 
 /// Translation providers. OpenAI / DeepSeek / Custom all speak the OpenAI
-/// chat-completions wire format; Claude and DeepL use their own APIs.
+/// chat-completions wire format; Claude, DeepL, and DeepLX use their own APIs.
 enum TranslationProviderKind: String, CaseIterable {
     case openai
     case deepseek
     case deepl
+    case deeplx
     case custom
     case claude
 
@@ -116,6 +117,7 @@ enum TranslationProviderKind: String, CaseIterable {
         case .openai:   return "OpenAI"
         case .deepseek: return "DeepSeek"
         case .deepl:    return "DeepL"
+        case .deeplx:   return "DeepLX"
         case .custom:   return L10n.translationProviderCustom
         case .claude:   return "Claude"
         }
@@ -127,11 +129,17 @@ enum TranslationProviderKind: String, CaseIterable {
     /// DeepL uses a non-SSE JSON response instead of chat completions.
     var isDeepL: Bool { self == .deepl }
 
+    /// DeepLX uses a non-SSE JSON response instead of chat completions.
+    var isDeepLX: Bool { self == .deeplx }
+
+    var isDirectTranslationAPI: Bool { isDeepL || isDeepLX }
+
     var defaultEndpoint: String {
         switch self {
         case .openai:   return "https://api.openai.com/v1/chat/completions"
         case .deepseek: return "https://api.deepseek.com/chat/completions"
         case .deepl:    return "https://api.deepl.com/v2/translate"
+        case .deeplx:   return "https://api.deeplx.org/{{apiKey}}/translate"
         case .custom:   return ""
         case .claude:   return "https://api.anthropic.com/v1/messages"
         }
@@ -142,6 +150,7 @@ enum TranslationProviderKind: String, CaseIterable {
         case .openai:   return "gpt-4o-mini"
         case .deepseek: return "deepseek-v4-flash"
         case .deepl:    return ""
+        case .deeplx:   return ""
         case .custom:   return ""
         case .claude:   return "claude-3-5-haiku-latest"
         }
@@ -173,6 +182,10 @@ extension TranslationLanguage {
         case .korean:     return "KO"
         case .turkish:    return "TR"
         }
+    }
+
+    var deepLXTargetCode: String {
+        deepLTargetCode.split(separator: "-").first.map(String.init) ?? deepLTargetCode
     }
 }
 

--- a/capcap/Translation/TranslationProvider.swift
+++ b/capcap/Translation/TranslationProvider.swift
@@ -159,6 +159,9 @@ enum TranslationProviderKind: String, CaseIterable {
     /// Custom must supply its own endpoint; the rest ship a sensible default
     /// but still allow an override (e.g. a proxy).
     var endpointRequired: Bool { self == .custom }
+
+    /// DeepLX can be self-hosted without an API key.
+    var isAPIKeyRequired: Bool { !isDeepLX }
 }
 
 extension TranslationLanguage {
@@ -324,7 +327,9 @@ enum TranslationConfigStore {
     /// True when the saved config has the fields a request needs.
     static func isConfigured(_ kind: TranslationProviderKind) -> Bool {
         let cfg = load(kind)
-        guard !cfg.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        if kind.isAPIKeyRequired {
+            guard !cfg.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        }
         if kind.endpointRequired {
             return !cfg.endpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }

--- a/capcap/Translation/TranslationService.swift
+++ b/capcap/Translation/TranslationService.swift
@@ -22,8 +22,8 @@ enum TranslationError: LocalizedError {
 }
 
 /// Streams translations. OpenAI / DeepSeek / Custom share the OpenAI
-/// chat-completions SSE format; Claude uses Anthropic Messages SSE; DeepL
-/// returns a single JSON payload that is yielded as one chunk.
+/// chat-completions SSE format; Claude uses Anthropic Messages SSE; DeepL and
+/// DeepLX return a single JSON payload that is yielded as one chunk.
 enum TranslationService {
 
     /// Yields translated text deltas as they arrive. Cancelling the consuming
@@ -34,7 +34,7 @@ enum TranslationService {
         kind: TranslationProviderKind,
         config: TranslationConfig
     ) -> AsyncThrowingStream<String, Error> {
-        if !kind.isDeepL {
+        if !kind.isDirectTranslationAPI {
             return streamChat(
                 text: text,
                 system: systemPrompt(for: target),
@@ -46,7 +46,9 @@ enum TranslationService {
         return AsyncThrowingStream { continuation in
             let work = Task.detached(priority: .userInitiated) {
                 do {
-                    let translated = try await translateWithDeepL(text: text, target: target, config: config)
+                    let translated = kind.isDeepLX
+                        ? try await translateWithDeepLX(text: text, target: target, config: config)
+                        : try await translateWithDeepL(text: text, target: target, config: config)
                     if !translated.isEmpty {
                         continuation.yield(translated)
                     }
@@ -81,7 +83,7 @@ enum TranslationService {
         kind: TranslationProviderKind,
         config: TranslationConfig
     ) async throws -> DictionaryEntry {
-        guard !kind.isDeepL else { throw TranslationError.badResponse }
+        guard !kind.isDirectTranslationAPI else { throw TranslationError.badResponse }
 
         var raw = ""
         let prompt = dictionaryUserPrompt(word: word)
@@ -360,6 +362,115 @@ enum TranslationService {
 
     private static func deepLBaseLanguage(_ code: String) -> String {
         code.uppercased().split(separator: "-").first.map(String.init) ?? code.uppercased()
+    }
+
+    // MARK: - DeepLX
+
+    private struct DeepLXTranslationResult {
+        let text: String
+        let detectedSourceLanguage: String?
+    }
+
+    private static func translateWithDeepLX(
+        text: String,
+        target: TranslationLanguage,
+        config: TranslationConfig
+    ) async throws -> String {
+        let result = try await requestDeepLXTranslation(text: text, target: target, config: config)
+        if target != .english,
+           deepLSourceMatchesTarget(result.detectedSourceLanguage, target: target) {
+            let fallback = try await requestDeepLXTranslation(text: text, target: .english, config: config)
+            return fallback.text
+        }
+        return result.text
+    }
+
+    private static func requestDeepLXTranslation(
+        text: String,
+        target: TranslationLanguage,
+        config: TranslationConfig
+    ) async throws -> DeepLXTranslationResult {
+        let request = try buildDeepLXRequest(text: text, target: target, config: config)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw TranslationError.badResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw TranslationError.http(http.statusCode, String(body.prefix(600)))
+        }
+        return try parseDeepLXResponse(data)
+    }
+
+    private static func buildDeepLXRequest(
+        text: String,
+        target: TranslationLanguage,
+        config: TranslationConfig
+    ) throws -> URLRequest {
+        let apiKey = config.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let endpoint = config.resolvedEndpoint(for: .deeplx)
+        guard !endpoint.contains("{{apiKey}}") || !apiKey.isEmpty else {
+            throw TranslationError.missingAPIKey
+        }
+        guard let url = URL(string: resolvedDeepLXEndpoint(endpoint: endpoint, apiKey: apiKey)),
+              url.scheme != nil else {
+            throw TranslationError.badEndpoint
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: 60)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty, !endpoint.contains("{{apiKey}}") {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = [
+            "text": text,
+            "source_lang": "auto",
+            "target_lang": target.deepLXTargetCode,
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private static func resolvedDeepLXEndpoint(endpoint: String, apiKey: String) -> String {
+        let encodedKey = apiKey.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? apiKey
+        return endpoint.replacingOccurrences(of: "{{apiKey}}", with: encodedKey)
+    }
+
+    private static func parseDeepLXResponse(_ data: Data) throws -> DeepLXTranslationResult {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw TranslationError.badResponse
+        }
+
+        if let code = json["code"] as? Int, code != 200 {
+            let message = json["message"] as? String ?? json["msg"] as? String ?? ""
+            throw TranslationError.http(code, message)
+        }
+
+        if let text = json["data"] as? String {
+            return DeepLXTranslationResult(
+                text: text,
+                detectedSourceLanguage: deepLXDetectedSourceLanguage(from: json)
+            )
+        }
+
+        if let data = json["data"] as? [String: Any],
+           let text = data["text"] as? String ?? data["translation"] as? String {
+            return DeepLXTranslationResult(
+                text: text,
+                detectedSourceLanguage: deepLXDetectedSourceLanguage(from: data) ?? deepLXDetectedSourceLanguage(from: json)
+            )
+        }
+
+        throw TranslationError.badResponse
+    }
+
+    private static func deepLXDetectedSourceLanguage(from json: [String: Any]) -> String? {
+        json["source_lang"] as? String
+            ?? json["sourceLang"] as? String
+            ?? json["detected_source_language"] as? String
     }
 
     // MARK: - SSE parsing


### PR DESCRIPTION
- 新增 \`TranslationProviderKind.deeplx\` 枚举及其配置
- 实现 DeepLX API 请求构建、端点解析、响应解析
- 翻译结果流式输出与 DeepL 共享同一条路径
- 设置页面中模型字段隐藏逻辑扩展到所有直译 API
- 字典模式排除检查扩展到所有直译 API"