### PR TITLE
feat(editor): Copy screenshots on double-click

### DIFF
--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -449,6 +449,10 @@ extension OverlayWindowController: SelectionViewDelegate {
         )
     }
 
+    func selectionDidDoubleClick(rect: NSRect, inView view: NSView) {
+        editController?.confirmFromCanvasDoubleClick()
+    }
+
     private func imageForImmediateAction(
         captureRect: CGRect,
         screen: NSScreen,

--- a/capcap/Capture/SelectionView.swift
+++ b/capcap/Capture/SelectionView.swift
@@ -9,10 +9,12 @@ protocol SelectionViewDelegate: AnyObject {
     ///   nil for free-drag / resize / preset selections.
     func selectionDidComplete(rect: NSRect, inView view: NSView, isWindowSelection: Bool, windowID: CGWindowID?)
     func selectionDidChange(rect: NSRect, inView view: NSView)
+    func selectionDidDoubleClick(rect: NSRect, inView view: NSView)
 }
 
 extension SelectionViewDelegate {
     func selectionDidChange(rect: NSRect, inView view: NSView) {}
+    func selectionDidDoubleClick(rect: NSRect, inView view: NSView) {}
 }
 
 class SelectionView: NSView {
@@ -184,6 +186,11 @@ class SelectionView: NSView {
             }
             // Check inside selection for move
             if rect.contains(point) {
+                if event.clickCount >= 2 {
+                    dragAction = .none
+                    delegate?.selectionDidDoubleClick(rect: rect, inView: self)
+                    return
+                }
                 if annotationToolActive {
                     // Let canvas handle it
                     return

--- a/capcap/Editor/EditCanvasView.swift
+++ b/capcap/Editor/EditCanvasView.swift
@@ -171,6 +171,8 @@ class EditCanvasView: NSView {
     /// Fired after the emoji tool stamps a sticker so the controller can clear
     /// the pending emoji without leaving the tool.
     var onEmojiStamped: (() -> Void)?
+    /// Fired when the user double-clicks the screenshot canvas.
+    var onCanvasDoubleClick: (() -> Void)?
 
     private func notifySelectionChanged() {
         guard let cb = onAnnotationSelected else { return }
@@ -924,6 +926,16 @@ class EditCanvasView: NSView {
         if let idx = hitTestAnnotation(at: point) {
             // Commit any in-progress text edit before grabbing something else.
             activeTextField?.commit()
+            if event.clickCount >= 2, activeTool == .none, !isShiftSelecting {
+                if selectedIndexes.count == 1,
+                   selectedIndex == idx,
+                   let textAnnotation = annotations[idx] as? TextAnnotation {
+                    reEditTextAnnotation(at: idx, annotation: textAnnotation)
+                } else {
+                    onCanvasDoubleClick?()
+                }
+                return
+            }
             if isShiftSelecting {
                 toggleSelection(of: idx)
                 refreshCursorAtCurrentLocation()
@@ -952,6 +964,12 @@ class EditCanvasView: NSView {
             )
             captureUndoForPending()
             NSCursor.closedHand.set()
+            return
+        }
+
+        if event.clickCount >= 2, activeTool == .none {
+            activeTextField?.commit()
+            onCanvasDoubleClick?()
             return
         }
 

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -158,6 +158,9 @@ class EditWindowController {
         canvas.onEmojiStamped = { [weak self] in
             self?.handleEmojiStamped()
         }
+        canvas.onCanvasDoubleClick = { [weak self] in
+            self?.confirmFromCanvasDoubleClick()
+        }
 
         let container = BeautifyContainerView(canvasView: canvas)
         container.autoresizingMask = []
@@ -1491,6 +1494,11 @@ class EditWindowController {
             confirmCrop()
             return
         }
+        confirm()
+    }
+
+    func confirmFromCanvasDoubleClick() {
+        guard !isScrollCapturing, !isCropping else { return }
         confirm()
     }
 


### PR DESCRIPTION
让用户通过在所选截图区域内双击来确认截图编辑器。通过现有的复制确认路径，将选择视图和画布上的双击操作都进行路由，以便编辑器关闭并一致地复制组合后的图像

属于我个人的使用体验，每次要点一下或者快捷键，双击鼠标不是更方便快捷吗