### PR TITLE
feat: 支持编辑器切换历史截图

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "Save to File";
 "fileSaveShortcutHint" = "Pressed inside the editor to save the screenshot as a PNG in the configured screenshot folder. Defaults to ⌘S";
+"previousHistoryImageShortcutHeader" = "Previous History Screenshot";
+"nextHistoryImageShortcutHeader" = "Next History Screenshot";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "Shortcut Already in Use";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "This key combination is already used by the Pin Clipboard Image shortcut. Please choose a different one";
 "shortcutConflictClipboard" = "This key combination is already used by the Copy to Clipboard shortcut. Please choose a different one";
 "shortcutConflictFileSave" = "This key combination is already used by the Save to File shortcut. Please choose a different one";
+"shortcutConflictPreviousHistoryImage" = "This key combination is already used by the Previous History Screenshot shortcut. Please choose a different one";
+"shortcutConflictNextHistoryImage" = "This key combination is already used by the Next History Screenshot shortcut. Please choose a different one";
 "shortcutConflictSelectedImageEdit" = "This key combination is already used by the Edit Selected Image shortcut. Please choose a different one";
 "shortcutConflictClipboardImageEdit" = "This key combination is already used by the Edit Clipboard Image shortcut. Please choose a different one";
 "shortcutConflictTextRecognition" = "This key combination is already used by the Text Recognition shortcut. Please choose a different one";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "Enregistrer dans un fichier";
 "fileSaveShortcutHint" = "Appuyez dessus dans l'éditeur pour enregistrer la capture en PNG dans le dossier de captures configuré. ⌘S par défaut";
+"previousHistoryImageShortcutHeader" = "Capture précédente de l'historique";
+"nextHistoryImageShortcutHeader" = "Capture suivante de l'historique";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "Raccourci déjà utilisé";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "Cette combinaison de touches est déjà utilisée par le raccourci d'épinglage de l'image du presse-papiers. Veuillez en choisir une autre";
 "shortcutConflictClipboard" = "Cette combinaison de touches est déjà utilisée par le raccourci de copie dans le presse-papiers. Veuillez en choisir une autre";
 "shortcutConflictFileSave" = "Cette combinaison de touches est déjà utilisée par le raccourci d'enregistrement dans un fichier. Veuillez en choisir une autre";
+"shortcutConflictPreviousHistoryImage" = "Cette combinaison de touches est déjà utilisée par le raccourci Capture précédente de l'historique. Veuillez en choisir une autre";
+"shortcutConflictNextHistoryImage" = "Cette combinaison de touches est déjà utilisée par le raccourci Capture suivante de l'historique. Veuillez en choisir une autre";
 "shortcutConflictSelectedImageEdit" = "Cette combinaison de touches est déjà utilisée par le raccourci Modifier l'image sélectionnée. Veuillez en choisir une autre";
 "shortcutConflictClipboardImageEdit" = "Cette combinaison de touches est déjà utilisée par le raccourci Modifier l'image du presse-papiers. Veuillez en choisir une autre";
 "shortcutConflictTextRecognition" = "Cette combinaison de touches est déjà utilisée par le raccourci Reconnaissance de texte. Veuillez en choisir une autre";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "ファイルへ保存";
 "fileSaveShortcutHint" = "エディター内で押すと、設定したスクリーンショット保存先へ PNG として保存します。既定は ⌘S";
+"previousHistoryImageShortcutHeader" = "前の履歴スクリーンショット";
+"nextHistoryImageShortcutHeader" = "次の履歴スクリーンショット";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "ショートカットは既に使用中です";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "このキーの組み合わせはクリップボード画像をピン留めのショートカットで既に使用されています。別の組み合わせを選んでください";
 "shortcutConflictClipboard" = "このキーの組み合わせはクリップボードへコピーのショートカットで既に使用されています。別の組み合わせを選んでください";
 "shortcutConflictFileSave" = "このキーの組み合わせはファイルへ保存のショートカットで既に使用されています。別の組み合わせを選んでください";
+"shortcutConflictPreviousHistoryImage" = "このキーの組み合わせは前の履歴スクリーンショットのショートカットで既に使用されています。別の組み合わせを選んでください";
+"shortcutConflictNextHistoryImage" = "このキーの組み合わせは次の履歴スクリーンショットのショートカットで既に使用されています。別の組み合わせを選んでください";
 "shortcutConflictSelectedImageEdit" = "このキーの組み合わせは選択画像を編集のショートカットで既に使用されています。別の組み合わせを選んでください";
 "shortcutConflictClipboardImageEdit" = "このキーの組み合わせはクリップボード画像を編集のショートカットで既に使用されています。別の組み合わせを選んでください";
 "shortcutConflictTextRecognition" = "このキーの組み合わせは文字認識ショートカットで既に使用されています。別の組み合わせを選んでください";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "파일로 저장";
 "fileSaveShortcutHint" = "편집기에서 누르면 설정된 스크린샷 폴더에 PNG로 저장합니다. 기본값은 ⌘S입니다";
+"previousHistoryImageShortcutHeader" = "이전 기록 스크린샷";
+"nextHistoryImageShortcutHeader" = "다음 기록 스크린샷";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "단축키가 이미 사용 중입니다";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "이 키 조합은 이미 클립보드 이미지 고정 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";
 "shortcutConflictClipboard" = "이 키 조합은 이미 클립보드에 복사 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";
 "shortcutConflictFileSave" = "이 키 조합은 이미 파일로 저장 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";
+"shortcutConflictPreviousHistoryImage" = "이 키 조합은 이미 이전 기록 스크린샷 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";
+"shortcutConflictNextHistoryImage" = "이 키 조합은 이미 다음 기록 스크린샷 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";
 "shortcutConflictSelectedImageEdit" = "이 키 조합은 이미 선택 이미지 편집 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";
 "shortcutConflictClipboardImageEdit" = "이 키 조합은 이미 클립보드 이미지 편집 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";
 "shortcutConflictTextRecognition" = "이 키 조합은 이미 문자 인식 단축키에 사용되고 있습니다. 다른 조합을 선택하세요";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "Сохранить в файл";
 "fileSaveShortcutHint" = "Нажмите в редакторе, чтобы сохранить снимок PNG в заданную папку снимков. По умолчанию — ⌘S";
+"previousHistoryImageShortcutHeader" = "Предыдущий снимок из истории";
+"nextHistoryImageShortcutHeader" = "Следующий снимок из истории";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "Сочетание уже используется";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "Это сочетание клавиш уже назначено для закрепления изображения из буфера. Выберите другое";
 "shortcutConflictClipboard" = "Это сочетание клавиш уже назначено для копирования в буфер обмена. Выберите другое";
 "shortcutConflictFileSave" = "Это сочетание клавиш уже назначено для сохранения в файл. Выберите другое";
+"shortcutConflictPreviousHistoryImage" = "Это сочетание клавиш уже назначено для предыдущего снимка из истории. Выберите другое";
+"shortcutConflictNextHistoryImage" = "Это сочетание клавиш уже назначено для следующего снимка из истории. Выберите другое";
 "shortcutConflictSelectedImageEdit" = "Это сочетание клавиш уже назначено для редактирования выбранного изображения. Выберите другое";
 "shortcutConflictClipboardImageEdit" = "Это сочетание клавиш уже назначено для редактирования изображения из буфера. Выберите другое";
 "shortcutConflictTextRecognition" = "Это сочетание клавиш уже назначено для распознавания текста. Выберите другое";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "Lưu vào tệp";
 "fileSaveShortcutHint" = "Nhấn trong trình chỉnh sửa để lưu ảnh chụp dạng PNG vào thư mục ảnh chụp đã đặt. Mặc định là ⌘S";
+"previousHistoryImageShortcutHeader" = "Ảnh chụp lịch sử trước";
+"nextHistoryImageShortcutHeader" = "Ảnh chụp lịch sử tiếp theo";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "Phím tắt đã được dùng";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "Tổ hợp phím này đã được dùng cho phím tắt ghim ảnh từ clipboard. Vui lòng chọn tổ hợp khác";
 "shortcutConflictClipboard" = "Tổ hợp phím này đã được dùng cho phím tắt sao chép vào clipboard. Vui lòng chọn tổ hợp khác";
 "shortcutConflictFileSave" = "Tổ hợp phím này đã được dùng cho phím tắt lưu vào tệp. Vui lòng chọn tổ hợp khác";
+"shortcutConflictPreviousHistoryImage" = "Tổ hợp phím này đã được dùng cho phím tắt ảnh chụp lịch sử trước. Vui lòng chọn tổ hợp khác";
+"shortcutConflictNextHistoryImage" = "Tổ hợp phím này đã được dùng cho phím tắt ảnh chụp lịch sử tiếp theo. Vui lòng chọn tổ hợp khác";
 "shortcutConflictSelectedImageEdit" = "Tổ hợp phím này đã được dùng cho phím tắt chỉnh sửa ảnh đã chọn. Vui lòng chọn tổ hợp khác";
 "shortcutConflictClipboardImageEdit" = "Tổ hợp phím này đã được dùng cho phím tắt chỉnh sửa ảnh từ clipboard. Vui lòng chọn tổ hợp khác";
 "shortcutConflictTextRecognition" = "Tổ hợp phím này đã được dùng cho phím tắt nhận dạng văn bản. Vui lòng chọn tổ hợp khác";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "保存到文件";
 "fileSaveShortcutHint" = "在编辑器内按下后，把截图保存为 PNG 到设置的截图保存路径。默认 ⌘S";
+"previousHistoryImageShortcutHeader" = "上一张历史截图";
+"nextHistoryImageShortcutHeader" = "下一张历史截图";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "快捷键已被占用";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "该按键组合已被钉起剪贴板图片快捷键占用，请换一个";
 "shortcutConflictClipboard" = "该按键组合已被复制到剪贴板快捷键占用，请换一个";
 "shortcutConflictFileSave" = "该按键组合已被保存到文件快捷键占用，请换一个";
+"shortcutConflictPreviousHistoryImage" = "该按键组合已被上一张历史截图快捷键占用，请换一个";
+"shortcutConflictNextHistoryImage" = "该按键组合已被下一张历史截图快捷键占用，请换一个";
 "shortcutConflictSelectedImageEdit" = "该按键组合已被编辑选中图片快捷键占用，请换一个";
 "shortcutConflictClipboardImageEdit" = "该按键组合已被编辑剪贴板图片快捷键占用，请换一个";
 "shortcutConflictTextRecognition" = "该按键组合已被文字识别快捷键占用，请换一个";

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -72,6 +72,8 @@
 /* Save-to-file shortcut (editor save) */
 "fileSaveShortcutHeader" = "儲存為檔案";
 "fileSaveShortcutHint" = "在編輯器中按下後，將截圖以 PNG 儲存到設定的截圖儲存路徑。預設為 ⌘S";
+"previousHistoryImageShortcutHeader" = "上一張歷史截圖";
+"nextHistoryImageShortcutHeader" = "下一張歷史截圖";
 
 /* Shortcut conflict */
 "shortcutConflictTitle" = "快捷鍵已被使用";
@@ -81,6 +83,8 @@
 "shortcutConflictClipboardImagePin" = "這組按鍵已用於釘選剪貼簿圖片快捷鍵。請選擇其他組合";
 "shortcutConflictClipboard" = "這組按鍵已用於複製到剪貼簿快捷鍵。請選擇其他組合";
 "shortcutConflictFileSave" = "這組按鍵已用於儲存為檔案快捷鍵。請選擇其他組合";
+"shortcutConflictPreviousHistoryImage" = "這組按鍵已用於上一張歷史截圖快捷鍵。請選擇其他組合";
+"shortcutConflictNextHistoryImage" = "這組按鍵已用於下一張歷史截圖快捷鍵。請選擇其他組合";
 "shortcutConflictSelectedImageEdit" = "這組按鍵已用於編輯所選圖片快捷鍵。請選擇其他組合";
 "shortcutConflictClipboardImageEdit" = "這組按鍵已用於編輯剪貼簿圖片快捷鍵。請選擇其他組合";
 "shortcutConflictTextRecognition" = "這組按鍵已用於文字辨識快捷鍵。請選擇其他組合";

--- a/capcap/Capture/HistoryManager.swift
+++ b/capcap/Capture/HistoryManager.swift
@@ -118,6 +118,15 @@ final class HistoryManager {
         return loadEntries()
     }
 
+    func imageEntries() -> [HistoryEntry] {
+        entries().filter { entry in
+            if case .image = entry.kind {
+                return true
+            }
+            return false
+        }
+    }
+
     func cacheDirectoryURL() -> URL {
         try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         return directoryURL

--- a/capcap/Capture/HistoryManager.swift
+++ b/capcap/Capture/HistoryManager.swift
@@ -119,11 +119,11 @@ final class HistoryManager {
     }
 
     func imageEntries() -> [HistoryEntry] {
-        entries().filter { entry in
-            if case .image = entry.kind {
-                return true
+        entries().filter {
+            guard case .image = $0.kind else {
+                return false
             }
-            return false
+            return true
         }
     }
 

--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -51,6 +51,9 @@ class OverlayWindowController {
     private var activeScreen: NSScreen?
     private var historyEntries: [HistoryEntry] = []
     private var historyEntryIndex: Int?
+    private var historyEditorDrafts: [URL: EditWindowController.RestorableState] = [:]
+    private var activeEditorContext: ActiveEditorContext?
+    private var currentEditHistoryDraft: CurrentEditHistoryDraft?
     private let windowDetector = WindowDetector()
     private var screenSnapshots: [CGDirectDisplayID: CGImage] = [:]
     private let onComplete: (NSImage?) -> Void
@@ -65,6 +68,61 @@ class OverlayWindowController {
     /// In image-edit mode, where `presetImage` came from. nil otherwise.
     private let presetSource: PresetSource?
     private var presentationScheduled = false
+
+    private struct ActiveEditorContext {
+        let captureRect: CGRect
+        let screen: NSScreen
+        let selectionRect: NSRect
+        let selectionViewRect: NSRect
+        weak var hostSelectionView: SelectionView?
+        let selectionViewState: SelectionViewState
+        let preSnapshot: CGImage?
+        let overrideBaseImage: NSImage?
+        let windowBaseImage: NSImage?
+        let isWindowCapture: Bool
+    }
+
+    private struct CurrentEditHistoryDraft {
+        let captureRect: CGRect
+        let screen: NSScreen
+        let selectionRect: NSRect
+        let selectionViewRect: NSRect
+        weak var hostSelectionView: SelectionView?
+        let selectionViewState: SelectionViewState
+        let preSnapshot: CGImage?
+        let overrideBaseImage: NSImage?
+        let windowBaseImage: NSImage?
+        let isWindowCapture: Bool
+        var editorState: EditWindowController.RestorableState?
+    }
+
+    private struct SelectionViewState {
+        let selectionSizeLabelOverride: String?
+        let selectionLocked: Bool
+        let selectionInteractionEnabled: Bool
+
+        init(selectionView: SelectionView) {
+            selectionSizeLabelOverride = selectionView.selectionSizeLabelOverride
+            selectionLocked = selectionView.selectionLocked
+            selectionInteractionEnabled = selectionView.selectionInteractionEnabled
+        }
+
+        init(
+            selectionSizeLabelOverride: String?,
+            selectionLocked: Bool,
+            selectionInteractionEnabled: Bool
+        ) {
+            self.selectionSizeLabelOverride = selectionSizeLabelOverride
+            self.selectionLocked = selectionLocked
+            self.selectionInteractionEnabled = selectionInteractionEnabled
+        }
+
+        func apply(to selectionView: SelectionView) {
+            selectionView.selectionSizeLabelOverride = selectionSizeLabelOverride
+            selectionView.selectionLocked = selectionLocked
+            selectionView.selectionInteractionEnabled = selectionInteractionEnabled
+        }
+    }
 
     /// Route the default copy-to-clipboard hotkey (double-tap ⌘) into the
     /// editor while the overlay is active. No-op when the editor isn't up yet.
@@ -429,6 +487,13 @@ class OverlayWindowController {
         }
         windows.removeAll()
         screenSnapshots.removeAll()
+        activeSelectionView = nil
+        activeScreen = nil
+        activeEditorContext = nil
+        currentEditHistoryDraft = nil
+        historyEditorDrafts.removeAll()
+        historyEntries.removeAll()
+        historyEntryIndex = nil
     }
 
     // MARK: - Coordinate Conversion
@@ -561,6 +626,8 @@ extension OverlayWindowController: SelectionViewDelegate {
             // Selection was adjusted — it no longer matches the clicked
             // window's bounds, so window-only effects no longer apply.
             historyEntryIndex = nil
+            currentEditHistoryDraft = nil
+            historyEditorDrafts.removeAll()
             editController?.isWindowCapture = false
             editController?.updateLayout(
                 selectionRect: screenRect,
@@ -581,6 +648,18 @@ extension OverlayWindowController: SelectionViewDelegate {
         windowBaseImage: NSImage?,
         isWindowCapture: Bool
     ) {
+        activeEditorContext = ActiveEditorContext(
+            captureRect: captureRect,
+            screen: screen,
+            selectionRect: selectionRect,
+            selectionViewRect: selectionViewRect,
+            hostSelectionView: hostSelectionView,
+            selectionViewState: SelectionViewState(selectionView: hostSelectionView),
+            preSnapshot: preSnapshot,
+            overrideBaseImage: overrideBaseImage,
+            windowBaseImage: windowBaseImage,
+            isWindowCapture: isWindowCapture
+        )
         editController = EditWindowController(
             captureRect: captureRect,
             screen: screen,
@@ -619,6 +698,16 @@ extension OverlayWindowController: SelectionViewDelegate {
     private func switchHistoryImage(offset: Int) -> Bool {
         refreshHistoryEntriesIfNeeded()
         guard !historyEntries.isEmpty else { return false }
+
+        if historyEntryIndex == nil {
+            guard offset > 0 else { return true }
+            captureCurrentEditHistoryDraftIfNeeded()
+        } else if historyEntryIndex == currentEditDraftIndex {
+            currentEditHistoryDraft?.editorState = editController?.restorableState()
+        } else {
+            captureCurrentHistoryEditorDraftIfNeeded()
+        }
+
         var nextIndex: Int
         if let currentIndex = historyEntryIndex {
             nextIndex = currentIndex + offset
@@ -626,7 +715,12 @@ extension OverlayWindowController: SelectionViewDelegate {
             guard offset > 0 else { return true }
             nextIndex = 0
         }
-        guard nextIndex >= 0, nextIndex < historyEntries.count else { return true }
+        let minimumIndex = currentEditHistoryDraft == nil ? 0 : -1
+        guard nextIndex >= minimumIndex, nextIndex < historyEntries.count else { return true }
+
+        if nextIndex == currentEditDraftIndex {
+            return restoreCurrentEditHistoryDraft(at: nextIndex)
+        }
 
         var image: NSImage?
         while nextIndex >= 0, nextIndex < historyEntries.count {
@@ -635,6 +729,9 @@ extension OverlayWindowController: SelectionViewDelegate {
                 break
             }
             nextIndex += offset
+        }
+        if nextIndex == currentEditDraftIndex {
+            return restoreCurrentEditHistoryDraft(at: nextIndex)
         }
         guard let image else {
             return true
@@ -669,6 +766,7 @@ extension OverlayWindowController: SelectionViewDelegate {
         activeSelectionView = selectionView
         activeScreen = screen
         historyEntryIndex = nextIndex
+        let historyDraft = historyEditorDrafts[historyEntries[nextIndex].fileURL]
 
         showEditor(
             captureRect: cgRect,
@@ -681,6 +779,77 @@ extension OverlayWindowController: SelectionViewDelegate {
             windowBaseImage: nil,
             isWindowCapture: false
         )
+        if let historyDraft {
+            editController?.restoreState(historyDraft)
+        }
+        return true
+    }
+
+    private var currentEditDraftIndex: Int? {
+        currentEditHistoryDraft == nil ? nil : -1
+    }
+
+    private func captureCurrentEditHistoryDraftIfNeeded() {
+        guard currentEditHistoryDraft == nil,
+              let editController,
+              let context = activeEditorContext,
+              let activeSelectionView = context.hostSelectionView
+        else { return }
+
+        currentEditHistoryDraft = CurrentEditHistoryDraft(
+            captureRect: context.captureRect,
+            screen: context.screen,
+            selectionRect: context.selectionRect,
+            selectionViewRect: context.selectionViewRect,
+            hostSelectionView: activeSelectionView,
+            selectionViewState: SelectionViewState(selectionView: activeSelectionView),
+            preSnapshot: context.preSnapshot,
+            overrideBaseImage: context.overrideBaseImage,
+            windowBaseImage: context.windowBaseImage,
+            isWindowCapture: editController.isWindowCapture,
+            editorState: editController.restorableState()
+        )
+    }
+
+    private func captureCurrentHistoryEditorDraftIfNeeded() {
+        guard let historyEntryIndex,
+              historyEntryIndex >= 0,
+              historyEntryIndex < historyEntries.count,
+              let editorState = editController?.restorableState()
+        else { return }
+
+        historyEditorDrafts[historyEntries[historyEntryIndex].fileURL] = editorState
+    }
+
+    private func restoreCurrentEditHistoryDraft(at index: Int) -> Bool {
+        guard let draft = currentEditHistoryDraft,
+              let selectionView = draft.hostSelectionView
+        else { return true }
+
+        editController?.tearDown()
+        editController = nil
+
+        selectionView.updateSelectionRect(draft.selectionViewRect)
+        draft.selectionViewState.apply(to: selectionView)
+
+        activeSelectionView = selectionView
+        activeScreen = draft.screen
+        historyEntryIndex = index
+
+        showEditor(
+            captureRect: draft.captureRect,
+            screen: draft.screen,
+            selectionRect: draft.selectionRect,
+            selectionViewRect: draft.selectionViewRect,
+            hostSelectionView: selectionView,
+            preSnapshot: draft.preSnapshot,
+            overrideBaseImage: draft.overrideBaseImage,
+            windowBaseImage: draft.windowBaseImage,
+            isWindowCapture: draft.isWindowCapture
+        )
+        if let editorState = draft.editorState {
+            editController?.restoreState(editorState)
+        }
         return true
     }
 
@@ -693,9 +862,29 @@ extension OverlayWindowController: SelectionViewDelegate {
         guard let _ = view.window else { return }
         // A resize/move drag changes the rect away from the clicked window.
         historyEntryIndex = nil
+        currentEditHistoryDraft = nil
+        historyEditorDrafts.removeAll()
         editController?.isWindowCapture = false
         let screenRect = convertToScreenRect(rect, view: view)
         let cgRect = convertToCGRect(screenRect)
+        if let context = activeEditorContext {
+            activeEditorContext = ActiveEditorContext(
+                captureRect: cgRect,
+                screen: context.screen,
+                selectionRect: screenRect,
+                selectionViewRect: rect,
+                hostSelectionView: context.hostSelectionView,
+                selectionViewState: SelectionViewState(
+                    selectionSizeLabelOverride: nil,
+                    selectionLocked: false,
+                    selectionInteractionEnabled: true
+                ),
+                preSnapshot: context.preSnapshot,
+                overrideBaseImage: context.overrideBaseImage,
+                windowBaseImage: nil,
+                isWindowCapture: false
+            )
+        }
         editController?.updateLayout(
             selectionRect: screenRect,
             selectionViewRect: rect,

--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -48,6 +48,9 @@ class OverlayWindowController {
     private var rightMouseGlobalMonitor: Any?
     private var editController: EditWindowController?
     private var activeSelectionView: SelectionView?
+    private var activeScreen: NSScreen?
+    private var historyEntries: [HistoryEntry] = []
+    private var historyEntryIndex: Int?
     private let windowDetector = WindowDetector()
     private var screenSnapshots: [CGDirectDisplayID: CGImage] = [:]
     private let onComplete: (NSImage?) -> Void
@@ -209,6 +212,9 @@ class OverlayWindowController {
                 return nil
             }
             if self?.editController?.deleteSelectedAnnotationFromKeyboard(for: event) == true {
+                return nil
+            }
+            if self?.switchHistoryImageFromKeyboard(for: event) == true {
                 return nil
             }
             if event.keyCode == 53 { // Escape
@@ -462,6 +468,7 @@ extension OverlayWindowController: SelectionViewDelegate {
             return
         }
         activeSelectionView = selectionView
+        activeScreen = screen
 
         let screenRect = convertToScreenRect(rect, view: view)
         let cgRect = convertToCGRect(screenRect)
@@ -539,7 +546,7 @@ extension OverlayWindowController: SelectionViewDelegate {
                 return
             }
 
-            editController = EditWindowController(
+            showEditor(
                 captureRect: cgRect,
                 screen: screen,
                 selectionRect: screenRect,
@@ -548,17 +555,12 @@ extension OverlayWindowController: SelectionViewDelegate {
                 preSnapshot: preSnapshot,
                 overrideBaseImage: presetImage,
                 windowBaseImage: windowBaseImage,
-                isWindowCapture: shouldApplyWindowEffects,
-                onRecordingSelection: onRecordingSelection,
-                onRequestFocusReturn: onRequestFocusReturn
-            ) { [weak self] finalImage in
-                self?.tearDown()
-                self?.onComplete(finalImage)
-            }
-            editController?.show()
+                isWindowCapture: shouldApplyWindowEffects
+            )
         } else {
             // Selection was adjusted — it no longer matches the clicked
             // window's bounds, so window-only effects no longer apply.
+            historyEntryIndex = nil
             editController?.isWindowCapture = false
             editController?.updateLayout(
                 selectionRect: screenRect,
@@ -568,9 +570,133 @@ extension OverlayWindowController: SelectionViewDelegate {
         }
     }
 
+    private func showEditor(
+        captureRect: CGRect,
+        screen: NSScreen,
+        selectionRect: NSRect,
+        selectionViewRect: NSRect,
+        hostSelectionView: SelectionView,
+        preSnapshot: CGImage?,
+        overrideBaseImage: NSImage?,
+        windowBaseImage: NSImage?,
+        isWindowCapture: Bool
+    ) {
+        editController = EditWindowController(
+            captureRect: captureRect,
+            screen: screen,
+            selectionRect: selectionRect,
+            selectionViewRect: selectionViewRect,
+            hostSelectionView: hostSelectionView,
+            preSnapshot: preSnapshot,
+            overrideBaseImage: overrideBaseImage,
+            windowBaseImage: windowBaseImage,
+            isWindowCapture: isWindowCapture,
+            onRecordingSelection: onRecordingSelection,
+            onRequestFocusReturn: onRequestFocusReturn
+        ) { [weak self] finalImage in
+            self?.tearDown()
+            self?.onComplete(finalImage)
+        }
+        editController?.show()
+    }
+
+    private func switchHistoryImageFromKeyboard(for event: NSEvent) -> Bool {
+        guard postCaptureAction == .edit,
+              let editController,
+              !editController.blocksHistoryNavigation
+        else {
+            return false
+        }
+        if HotkeyManager.eventMatchesPreviousHistoryImageHotkey(event) {
+            return switchHistoryImage(offset: 1)
+        }
+        if HotkeyManager.eventMatchesNextHistoryImageHotkey(event) {
+            return switchHistoryImage(offset: -1)
+        }
+        return false
+    }
+
+    private func switchHistoryImage(offset: Int) -> Bool {
+        refreshHistoryEntriesIfNeeded()
+        guard !historyEntries.isEmpty else { return false }
+        var nextIndex: Int
+        if let currentIndex = historyEntryIndex {
+            nextIndex = currentIndex + offset
+        } else {
+            guard offset > 0 else { return true }
+            nextIndex = 0
+        }
+        guard nextIndex >= 0, nextIndex < historyEntries.count else { return true }
+
+        var image: NSImage?
+        while nextIndex >= 0, nextIndex < historyEntries.count {
+            image = HistoryManager.shared.image(for: historyEntries[nextIndex])
+            if image != nil {
+                break
+            }
+            historyEntries.remove(at: nextIndex)
+            if offset < 0 {
+                nextIndex += offset
+            }
+        }
+        guard let image else {
+            historyEntryIndex = nil
+            return true
+        }
+        guard let screen = activeScreen ?? NSScreen.screens.first,
+              let window = windows.first(where: { $0.screen == screen }),
+              let selectionView = window.contentView as? SelectionView
+        else { return false }
+
+        editController?.tearDown()
+        editController = nil
+
+        let displayMetrics = Self.displayMetrics(for: image.size, on: screen)
+        let visibleRect = Self.visibleRectInSelectionView(for: screen)
+        let viewRect = NSRect(
+            x: visibleRect.midX - displayMetrics.viewportSize.width / 2,
+            y: visibleRect.midY - displayMetrics.viewportSize.height / 2,
+            width: displayMetrics.viewportSize.width,
+            height: displayMetrics.viewportSize.height
+        )
+        let screenRect = convertToScreenRect(viewRect, view: selectionView)
+        let cgRect = convertToCGRect(screenRect)
+
+        selectionView.updateSelectionRect(viewRect)
+        selectionView.selectionSizeLabelOverride = Self.scaleLabelText(
+            imageSize: image.size,
+            displaySize: displayMetrics.canvasSize
+        )
+        selectionView.selectionLocked = true
+        selectionView.selectionInteractionEnabled = false
+
+        activeSelectionView = selectionView
+        activeScreen = screen
+        historyEntryIndex = nextIndex
+
+        showEditor(
+            captureRect: cgRect,
+            screen: screen,
+            selectionRect: screenRect,
+            selectionViewRect: viewRect,
+            hostSelectionView: selectionView,
+            preSnapshot: nil,
+            overrideBaseImage: image,
+            windowBaseImage: nil,
+            isWindowCapture: false
+        )
+        return true
+    }
+
+    private func refreshHistoryEntriesIfNeeded() {
+        guard historyEntries.isEmpty else { return }
+        historyEntries = HistoryManager.shared.imageEntries()
+    }
+
     func selectionDidChange(rect: NSRect, inView view: NSView) {
         guard let _ = view.window else { return }
         // A resize/move drag changes the rect away from the clicked window.
+        historyEntryIndex = nil
         editController?.isWindowCapture = false
         let screenRect = convertToScreenRect(rect, view: view)
         let cgRect = convertToCGRect(screenRect)

--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -634,13 +634,9 @@ extension OverlayWindowController: SelectionViewDelegate {
             if image != nil {
                 break
             }
-            historyEntries.remove(at: nextIndex)
-            if offset < 0 {
-                nextIndex += offset
-            }
+            nextIndex += offset
         }
         guard let image else {
-            historyEntryIndex = nil
             return true
         }
         guard let screen = activeScreen ?? NSScreen.screens.first,

--- a/capcap/Editor/EditCanvasView.swift
+++ b/capcap/Editor/EditCanvasView.swift
@@ -413,10 +413,20 @@ class EditCanvasView: NSView {
 
     // MARK: - Undo / Redo
 
+    struct RestorableState {
+        fileprivate let annotations: [Annotation]
+        fileprivate let numberCounter: Int
+        fileprivate let selectedIndexes: Set<Int>
+        fileprivate let primarySelectedIndex: Int?
+        fileprivate let undoStack: [EditorSnapshot]
+        fileprivate let redoStack: [EditorSnapshot]
+        fileprivate let previewImage: NSImage?
+    }
+
     /// History snapshot. Annotations are value-typed (struct) so a plain
     /// array copy is a deep copy of the editor's logical state. The number
     /// counter is included so undo/redo also restores the next-badge value.
-    private struct EditorSnapshot {
+    fileprivate struct EditorSnapshot {
         let annotations: [Annotation]
         let numberCounter: Int
     }
@@ -434,6 +444,35 @@ class EditCanvasView: NSView {
 
     private func currentSnapshot() -> EditorSnapshot {
         EditorSnapshot(annotations: annotations, numberCounter: numberCounter)
+    }
+
+    func restorableState() -> RestorableState {
+        activeTextField?.commit()
+        return RestorableState(
+            annotations: annotations,
+            numberCounter: numberCounter,
+            selectedIndexes: selectedIndexes,
+            primarySelectedIndex: primarySelectedIndex,
+            undoStack: undoStack,
+            redoStack: redoStack,
+            previewImage: previewImage
+        )
+    }
+
+    func restoreState(_ state: RestorableState) {
+        cancelInFlightInteraction()
+        previewImage = state.previewImage
+        if let previewImage {
+            setFrameSize(previewImage.size)
+        }
+        annotations = state.annotations
+        numberCounter = state.numberCounter
+        undoStack = state.undoStack
+        redoStack = state.redoStack
+        setSelectedIndexes(state.selectedIndexes, primary: state.primarySelectedIndex)
+        needsDisplay = true
+        notifyHistoryStateChanged()
+        refreshCursorAtCurrentLocation()
     }
 
     private func apply(_ snapshot: EditorSnapshot) {

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -72,6 +72,18 @@ class EditWindowController {
         isScrollCapturing || isCropping
     }
 
+    struct RestorableState {
+        let canvasState: EditCanvasView.RestorableState
+        let beautifyState: BeautifyState
+    }
+
+    struct BeautifyState {
+        let isActive: Bool
+        let presetID: String?
+        let padding: CGFloat
+        let shadowEnabled: Bool
+    }
+
     // Drawing properties
     private var currentColor: NSColor = EditorStyleDefaults.primaryColor
     private var currentLineWidth: CGFloat = EditorStyleDefaults.standardLineWidth
@@ -1898,6 +1910,68 @@ class EditWindowController {
         } else {
             hostWindow.makeFirstResponder(canvasView)
         }
+    }
+
+    func restorableState() -> RestorableState? {
+        guard let canvasView else { return nil }
+        return RestorableState(
+            canvasState: canvasView.restorableState(),
+            beautifyState: BeautifyState(
+                isActive: isBeautifyActive,
+                presetID: currentBeautifyPreset?.id,
+                padding: currentBeautifyPadding,
+                shadowEnabled: currentBeautifyShadowEnabled
+            )
+        )
+    }
+
+    func restoreState(_ state: RestorableState) {
+        if state.beautifyState.isActive {
+            applyBeautifyState(state.beautifyState)
+        } else if isBeautifyActive {
+            deactivateBeautify()
+        }
+        canvasView?.restoreState(state.canvasState)
+        beautifyContainerView?.canvasSizeDidChange()
+        if state.beautifyState.isActive {
+            updateCanvasFrameForBeautify()
+            repositionFloatingChrome()
+        }
+        updateCanvasScrollAvailability()
+        updateEditorInteractionState()
+        updateHistoryButtons(canUndo: canvasView?.canUndo == true, canRedo: canvasView?.canRedo == true)
+    }
+
+    private func applyBeautifyState(_ state: BeautifyState) {
+        guard let canvasView, let container = beautifyContainerView else { return }
+        let preset = BeautifyPreset.preset(forID: state.presetID) ?? .defaultPreset
+
+        canvasView.beautifyCornerRadius = isWindowCapture ? nil : BeautifyRenderer.innerCornerRadius
+        container.setInnerShadowCornerRadius(
+            isWindowCapture ? WindowEffects.cornerRadiusPoints : BeautifyRenderer.innerCornerRadius
+        )
+        container.setInnerShadowInset(
+            isWindowCapture ? BeautifyRenderer.windowInnerShadowInset : 0
+        )
+        if canvasView.previewImage == nil, canvasView.externalBaseImage == nil {
+            canvasView.externalBaseImage = windowShapedBaseImage(
+                from: canvasView.resolveBaseImageForEditing()
+            )
+        }
+
+        currentBeautifyPreset = preset
+        currentBeautifyPadding = state.padding
+        currentBeautifyShadowEnabled = state.shadowEnabled
+        if preset.isWallpaper {
+            container.wallpaperImage = nil
+            loadBeautifyWallpaper(presetID: preset.id)
+        }
+        container.setBeautify(preset: preset)
+        container.setPadding(state.padding)
+        container.setShadowEnabled(state.shadowEnabled)
+        isBeautifyActive = true
+        toolbars.forEach { $0.setBeautifyActive(true) }
+        showBeautifySubToolbar(selecting: preset)
     }
 
     private func currentCompositeImage() -> NSImage? {

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -68,6 +68,10 @@ class EditWindowController {
     private var scrollCropView: ScrollCropView?
     private var scrollCropControlWindow: ScrollCropControlWindow?
 
+    var blocksHistoryNavigation: Bool {
+        isScrollCapturing || isCropping
+    }
+
     // Drawing properties
     private var currentColor: NSColor = EditorStyleDefaults.primaryColor
     private var currentLineWidth: CGFloat = EditorStyleDefaults.standardLineWidth

--- a/capcap/Settings/SettingsView.swift
+++ b/capcap/Settings/SettingsView.swift
@@ -179,6 +179,19 @@ class SettingsView: NSView {
     private var fileSaveShortcutRestoreButton: NSButton!
     private var fileSaveShortcutRecordingMonitor: Any?
 
+    // History navigation shortcut cards
+    private var previousHistoryImageShortcutTitleLabel: NSTextField!
+    private var previousHistoryImageShortcutField: NSTextField!
+    private var previousHistoryImageShortcutSetButton: NSButton!
+    private var previousHistoryImageShortcutRestoreButton: NSButton!
+    private var previousHistoryImageShortcutRecordingMonitor: Any?
+
+    private var nextHistoryImageShortcutTitleLabel: NSTextField!
+    private var nextHistoryImageShortcutField: NSTextField!
+    private var nextHistoryImageShortcutSetButton: NSButton!
+    private var nextHistoryImageShortcutRestoreButton: NSButton!
+    private var nextHistoryImageShortcutRecordingMonitor: Any?
+
     private var shortcutResetButton: NSButton?
 
     // Permission badges
@@ -304,6 +317,8 @@ class SettingsView: NSView {
         cancelImageMergeShortcutRecording()
         cancelClipboardShortcutRecording()
         cancelFileSaveShortcutRecording()
+        cancelPreviousHistoryImageShortcutRecording()
+        cancelNextHistoryImageShortcutRecording()
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -379,6 +394,8 @@ class SettingsView: NSView {
         refreshImageMergeShortcutDisplay()
         refreshClipboardShortcutDisplay()
         refreshFileSaveShortcutDisplay()
+        refreshPreviousHistoryImageShortcutDisplay()
+        refreshNextHistoryImageShortcutDisplay()
     }
 
     // MARK: - Sidebar
@@ -772,6 +789,30 @@ class SettingsView: NSView {
         fileSaveShortcutRestoreButton = fileSaveShortcut.restoreButton
         stack.addArrangedSubview(fileSaveShortcut.card)
         fileSaveShortcut.card.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        let previousHistoryImageShortcut = buildShortcutCard(
+            title: L10n.previousHistoryImageShortcutHeader,
+            setAction: #selector(previousHistoryImageShortcutSetClicked),
+            restoreAction: #selector(previousHistoryImageShortcutRestoreClicked)
+        )
+        previousHistoryImageShortcutTitleLabel = previousHistoryImageShortcut.title
+        previousHistoryImageShortcutField = previousHistoryImageShortcut.field
+        previousHistoryImageShortcutSetButton = previousHistoryImageShortcut.setButton
+        previousHistoryImageShortcutRestoreButton = previousHistoryImageShortcut.restoreButton
+        stack.addArrangedSubview(previousHistoryImageShortcut.card)
+        previousHistoryImageShortcut.card.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        let nextHistoryImageShortcut = buildShortcutCard(
+            title: L10n.nextHistoryImageShortcutHeader,
+            setAction: #selector(nextHistoryImageShortcutSetClicked),
+            restoreAction: #selector(nextHistoryImageShortcutRestoreClicked)
+        )
+        nextHistoryImageShortcutTitleLabel = nextHistoryImageShortcut.title
+        nextHistoryImageShortcutField = nextHistoryImageShortcut.field
+        nextHistoryImageShortcutSetButton = nextHistoryImageShortcut.setButton
+        nextHistoryImageShortcutRestoreButton = nextHistoryImageShortcut.restoreButton
+        stack.addArrangedSubview(nextHistoryImageShortcut.card)
+        nextHistoryImageShortcut.card.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
         // Full-screen screenshot shortcut card
         let fullScreenScreenshotShortcut = buildShortcutCard(
@@ -2511,6 +2552,12 @@ class SettingsView: NSView {
         if slot != .fileSave, fileSaveShortcutRecordingMonitor != nil {
             cancelFileSaveShortcutRecording()
         }
+        if slot != .previousHistoryImage, previousHistoryImageShortcutRecordingMonitor != nil {
+            cancelPreviousHistoryImageShortcutRecording()
+        }
+        if slot != .nextHistoryImage, nextHistoryImageShortcutRecordingMonitor != nil {
+            cancelNextHistoryImageShortcutRecording()
+        }
     }
 
     @objc private func shortcutSetClicked() {
@@ -3729,6 +3776,160 @@ class SettingsView: NSView {
         fileSaveShortcutRestoreButton?.isHidden = !Defaults.hasCustomFileSaveHotkey
     }
 
+    @objc private func previousHistoryImageShortcutSetClicked() {
+        if previousHistoryImageShortcutRecordingMonitor != nil {
+            cancelPreviousHistoryImageShortcutRecording()
+            return
+        }
+        cancelShortcutRecordings(except: .previousHistoryImage)
+        HotkeyManager.shared.beginRecording()
+        previousHistoryImageShortcutSetButton.title = L10n.shortcutCancel
+        previousHistoryImageShortcutField.stringValue = L10n.shortcutWaiting
+        previousHistoryImageShortcutRestoreButton.isHidden = true
+
+        previousHistoryImageShortcutRecordingMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self = self else { return event }
+            let modifiers = event.modifierFlags
+            let isEscape = event.keyCode == UInt16(kVK_Escape)
+            let activeModifierMask: NSEvent.ModifierFlags = [.command, .shift, .option, .control]
+            let pressedModifiers = modifiers.intersection(activeModifierMask)
+
+            if isEscape && pressedModifiers.isEmpty {
+                self.cancelPreviousHistoryImageShortcutRecording()
+                return nil
+            }
+
+            var carbonMods: UInt32 = 0
+            if modifiers.contains(.command) { carbonMods |= UInt32(cmdKey) }
+            if modifiers.contains(.shift)   { carbonMods |= UInt32(shiftKey) }
+            if modifiers.contains(.option)  { carbonMods |= UInt32(optionKey) }
+            if modifiers.contains(.control) { carbonMods |= UInt32(controlKey) }
+            let keyCode = UInt32(event.keyCode)
+
+            if let conflict = HotkeyManager.shared.hotkeyConflictMessage(
+                forKeyCode: keyCode, modifiers: carbonMods, assigningTo: .previousHistoryImage) {
+                self.cancelPreviousHistoryImageShortcutRecording()
+                self.presentHotkeyConflictAlert(conflict)
+                return nil
+            }
+
+            Defaults.previousHistoryImageHotkeyKeyCode = Int(keyCode)
+            Defaults.previousHistoryImageHotkeyModifiers = Int(carbonMods)
+            self.finishPreviousHistoryImageShortcutRecording()
+            return nil
+        }
+    }
+
+    @objc private func previousHistoryImageShortcutRestoreClicked() {
+        if previousHistoryImageShortcutRecordingMonitor != nil {
+            cancelPreviousHistoryImageShortcutRecording()
+        }
+        Defaults.clearPreviousHistoryImageHotkey()
+        refreshPreviousHistoryImageShortcutDisplay()
+    }
+
+    private func finishPreviousHistoryImageShortcutRecording() {
+        if let m = previousHistoryImageShortcutRecordingMonitor {
+            NSEvent.removeMonitor(m)
+            previousHistoryImageShortcutRecordingMonitor = nil
+        }
+        HotkeyManager.shared.endRecording()
+        refreshPreviousHistoryImageShortcutDisplay()
+    }
+
+    func cancelPreviousHistoryImageShortcutRecording() {
+        guard previousHistoryImageShortcutRecordingMonitor != nil else { return }
+        if let m = previousHistoryImageShortcutRecordingMonitor {
+            NSEvent.removeMonitor(m)
+            previousHistoryImageShortcutRecordingMonitor = nil
+        }
+        HotkeyManager.shared.endRecording()
+        refreshPreviousHistoryImageShortcutDisplay()
+    }
+
+    private func refreshPreviousHistoryImageShortcutDisplay() {
+        previousHistoryImageShortcutSetButton?.title = L10n.shortcutSet
+        previousHistoryImageShortcutField?.stringValue = HotkeyManager.currentPreviousHistoryImageDisplayString()
+        previousHistoryImageShortcutRestoreButton?.isHidden = !Defaults.hasCustomPreviousHistoryImageHotkey
+    }
+
+    @objc private func nextHistoryImageShortcutSetClicked() {
+        if nextHistoryImageShortcutRecordingMonitor != nil {
+            cancelNextHistoryImageShortcutRecording()
+            return
+        }
+        cancelShortcutRecordings(except: .nextHistoryImage)
+        HotkeyManager.shared.beginRecording()
+        nextHistoryImageShortcutSetButton.title = L10n.shortcutCancel
+        nextHistoryImageShortcutField.stringValue = L10n.shortcutWaiting
+        nextHistoryImageShortcutRestoreButton.isHidden = true
+
+        nextHistoryImageShortcutRecordingMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self = self else { return event }
+            let modifiers = event.modifierFlags
+            let isEscape = event.keyCode == UInt16(kVK_Escape)
+            let activeModifierMask: NSEvent.ModifierFlags = [.command, .shift, .option, .control]
+            let pressedModifiers = modifiers.intersection(activeModifierMask)
+
+            if isEscape && pressedModifiers.isEmpty {
+                self.cancelNextHistoryImageShortcutRecording()
+                return nil
+            }
+
+            var carbonMods: UInt32 = 0
+            if modifiers.contains(.command) { carbonMods |= UInt32(cmdKey) }
+            if modifiers.contains(.shift)   { carbonMods |= UInt32(shiftKey) }
+            if modifiers.contains(.option)  { carbonMods |= UInt32(optionKey) }
+            if modifiers.contains(.control) { carbonMods |= UInt32(controlKey) }
+            let keyCode = UInt32(event.keyCode)
+
+            if let conflict = HotkeyManager.shared.hotkeyConflictMessage(
+                forKeyCode: keyCode, modifiers: carbonMods, assigningTo: .nextHistoryImage) {
+                self.cancelNextHistoryImageShortcutRecording()
+                self.presentHotkeyConflictAlert(conflict)
+                return nil
+            }
+
+            Defaults.nextHistoryImageHotkeyKeyCode = Int(keyCode)
+            Defaults.nextHistoryImageHotkeyModifiers = Int(carbonMods)
+            self.finishNextHistoryImageShortcutRecording()
+            return nil
+        }
+    }
+
+    @objc private func nextHistoryImageShortcutRestoreClicked() {
+        if nextHistoryImageShortcutRecordingMonitor != nil {
+            cancelNextHistoryImageShortcutRecording()
+        }
+        Defaults.clearNextHistoryImageHotkey()
+        refreshNextHistoryImageShortcutDisplay()
+    }
+
+    private func finishNextHistoryImageShortcutRecording() {
+        if let m = nextHistoryImageShortcutRecordingMonitor {
+            NSEvent.removeMonitor(m)
+            nextHistoryImageShortcutRecordingMonitor = nil
+        }
+        HotkeyManager.shared.endRecording()
+        refreshNextHistoryImageShortcutDisplay()
+    }
+
+    func cancelNextHistoryImageShortcutRecording() {
+        guard nextHistoryImageShortcutRecordingMonitor != nil else { return }
+        if let m = nextHistoryImageShortcutRecordingMonitor {
+            NSEvent.removeMonitor(m)
+            nextHistoryImageShortcutRecordingMonitor = nil
+        }
+        HotkeyManager.shared.endRecording()
+        refreshNextHistoryImageShortcutDisplay()
+    }
+
+    private func refreshNextHistoryImageShortcutDisplay() {
+        nextHistoryImageShortcutSetButton?.title = L10n.shortcutSet
+        nextHistoryImageShortcutField?.stringValue = HotkeyManager.currentNextHistoryImageDisplayString()
+        nextHistoryImageShortcutRestoreButton?.isHidden = !Defaults.hasCustomNextHistoryImageHotkey
+    }
+
     @objc private func shortcutsResetClicked() {
         cancelShortcutRecording()
         cancelFullScreenScreenshotShortcutRecording()
@@ -3744,6 +3945,8 @@ class SettingsView: NSView {
         cancelImageMergeShortcutRecording()
         cancelClipboardShortcutRecording()
         cancelFileSaveShortcutRecording()
+        cancelPreviousHistoryImageShortcutRecording()
+        cancelNextHistoryImageShortcutRecording()
 
         Defaults.resetShortcutHotkeysToDefaults()
         NotificationCenter.default.post(name: .hotkeyDidChange, object: nil)
@@ -3761,6 +3964,8 @@ class SettingsView: NSView {
         refreshImageMergeShortcutDisplay()
         refreshClipboardShortcutDisplay()
         refreshFileSaveShortcutDisplay()
+        refreshPreviousHistoryImageShortcutDisplay()
+        refreshNextHistoryImageShortcutDisplay()
     }
 
     @objc private func updateLocalization() {
@@ -3827,6 +4032,10 @@ class SettingsView: NSView {
         clipboardShortcutRestoreButton?.toolTip = L10n.shortcutRestore
         fileSaveShortcutTitleLabel?.stringValue = L10n.fileSaveShortcutHeader
         fileSaveShortcutRestoreButton?.toolTip = L10n.shortcutRestore
+        previousHistoryImageShortcutTitleLabel?.stringValue = L10n.previousHistoryImageShortcutHeader
+        previousHistoryImageShortcutRestoreButton?.toolTip = L10n.shortcutRestore
+        nextHistoryImageShortcutTitleLabel?.stringValue = L10n.nextHistoryImageShortcutHeader
+        nextHistoryImageShortcutRestoreButton?.toolTip = L10n.shortcutRestore
         shortcutResetButton?.title = L10n.toolbarSettingsReset
         aboutTaglineLabel?.stringValue = L10n.aboutTagline
         aboutLicenseTitleLabel?.stringValue = L10n.aboutLicense
@@ -3859,6 +4068,8 @@ class SettingsView: NSView {
         refreshImageMergeShortcutDisplay()
         refreshClipboardShortcutDisplay()
         refreshFileSaveShortcutDisplay()
+        refreshPreviousHistoryImageShortcutDisplay()
+        refreshNextHistoryImageShortcutDisplay()
         refreshBottomAction()
         accessibilityBadge?.refreshTitle()
         screenRecordingBadge?.refreshTitle()

--- a/capcap/Trigger/HotkeyManager.swift
+++ b/capcap/Trigger/HotkeyManager.swift
@@ -700,6 +700,42 @@ final class HotkeyManager {
         return matches(event: event, keyCode: kc, modifiers: m)
     }
 
+    func currentPreviousHistoryImageHotkey() -> (keyCode: UInt32, modifiers: UInt32) {
+        if Defaults.hasCustomPreviousHistoryImageHotkey {
+            return (UInt32(Defaults.previousHistoryImageHotkeyKeyCode),
+                    UInt32(Defaults.previousHistoryImageHotkeyModifiers))
+        }
+        return (UInt32(kVK_ANSI_Comma), 0)
+    }
+
+    static func currentPreviousHistoryImageDisplayString() -> String {
+        let (kc, mods) = HotkeyManager.shared.currentPreviousHistoryImageHotkey()
+        return modifierString(mods) + keyString(kc)
+    }
+
+    static func eventMatchesPreviousHistoryImageHotkey(_ event: NSEvent) -> Bool {
+        let (kc, m) = HotkeyManager.shared.currentPreviousHistoryImageHotkey()
+        return matches(event: event, keyCode: kc, modifiers: m)
+    }
+
+    func currentNextHistoryImageHotkey() -> (keyCode: UInt32, modifiers: UInt32) {
+        if Defaults.hasCustomNextHistoryImageHotkey {
+            return (UInt32(Defaults.nextHistoryImageHotkeyKeyCode),
+                    UInt32(Defaults.nextHistoryImageHotkeyModifiers))
+        }
+        return (UInt32(kVK_ANSI_Period), 0)
+    }
+
+    static func currentNextHistoryImageDisplayString() -> String {
+        let (kc, mods) = HotkeyManager.shared.currentNextHistoryImageHotkey()
+        return modifierString(mods) + keyString(kc)
+    }
+
+    static func eventMatchesNextHistoryImageHotkey(_ event: NSEvent) -> Bool {
+        let (kc, m) = HotkeyManager.shared.currentNextHistoryImageHotkey()
+        return matches(event: event, keyCode: kc, modifiers: m)
+    }
+
     private static func matches(event: NSEvent, keyCode: UInt32, modifiers: UInt32) -> Bool {
         let activeMask: NSEvent.ModifierFlags = [.command, .shift, .option, .control]
         let mods = event.modifierFlags.intersection(activeMask)
@@ -729,6 +765,8 @@ final class HotkeyManager {
         case colorPicker
         case clipboard
         case fileSave
+        case previousHistoryImage
+        case nextHistoryImage
     }
 
     /// Returns a localized message describing the existing binding a candidate
@@ -878,6 +916,30 @@ final class HotkeyManager {
             let (kc, m) = currentFileSaveHotkey()
             if kc == keyCode, m == modifiers {
                 return L10n.shortcutConflictFileSave
+            }
+        }
+        if slot != .previousHistoryImage {
+            let (kc, m) = currentPreviousHistoryImageHotkey()
+            if kc == keyCode {
+                if m == modifiers {
+                    return L10n.shortcutConflictPreviousHistoryImage
+                }
+                if slot == .screenshot, modifiers & UInt32(optionKey) == 0,
+                   m == modifiers | UInt32(optionKey) {
+                    return L10n.shortcutConflictPreviousHistoryImage
+                }
+            }
+        }
+        if slot != .nextHistoryImage {
+            let (kc, m) = currentNextHistoryImageHotkey()
+            if kc == keyCode {
+                if m == modifiers {
+                    return L10n.shortcutConflictNextHistoryImage
+                }
+                if slot == .screenshot, modifiers & UInt32(optionKey) == 0,
+                   m == modifiers | UInt32(optionKey) {
+                    return L10n.shortcutConflictNextHistoryImage
+                }
             }
         }
         return nil

--- a/capcap/Utilities/Defaults.swift
+++ b/capcap/Utilities/Defaults.swift
@@ -160,6 +160,10 @@ enum L10n {
     static var clipboardShortcutHint: String { s("clipboardShortcutHint") }
     static var clipboardShortcutDefaultDisplay: String { s("clipboardShortcutDefaultDisplay") }
 
+    // History navigation shortcuts (editor)
+    static var previousHistoryImageShortcutHeader: String { s("previousHistoryImageShortcutHeader") }
+    static var nextHistoryImageShortcutHeader: String { s("nextHistoryImageShortcutHeader") }
+
     // Save-to-file shortcut (editor save)
     static var fileSaveShortcutHeader: String { s("fileSaveShortcutHeader") }
     static var fileSaveShortcutHint: String { s("fileSaveShortcutHint") }
@@ -172,6 +176,8 @@ enum L10n {
     static var shortcutConflictClipboardImagePin: String { s("shortcutConflictClipboardImagePin") }
     static var shortcutConflictClipboard: String { s("shortcutConflictClipboard") }
     static var shortcutConflictFileSave: String { s("shortcutConflictFileSave") }
+    static var shortcutConflictPreviousHistoryImage: String { s("shortcutConflictPreviousHistoryImage") }
+    static var shortcutConflictNextHistoryImage: String { s("shortcutConflictNextHistoryImage") }
     static var shortcutConflictSelectedImageEdit: String { s("shortcutConflictSelectedImageEdit") }
     static var shortcutConflictClipboardImageEdit: String { s("shortcutConflictClipboardImageEdit") }
     static var shortcutConflictTextRecognition: String { s("shortcutConflictTextRecognition") }
@@ -714,6 +720,8 @@ struct Defaults {
         clearColorPickerHotkey()
         clearClipboardHotkey()
         clearFileSaveHotkey()
+        clearPreviousHistoryImageHotkey()
+        clearNextHistoryImageHotkey()
     }
 
     // Custom image-edit hotkeys. They are global Carbon hotkeys with no
@@ -1170,6 +1178,48 @@ struct Defaults {
     static func clearFileSaveHotkey() {
         defaults.removeObject(forKey: "fileSaveHotkeyKeyCode")
         defaults.removeObject(forKey: "fileSaveHotkeyModifiers")
+    }
+
+    // History navigation hotkeys used inside the editor overlay. Defaults are
+    // comma for previous and period for next. Like clipboard/save editor
+    // hotkeys, bare keys are allowed because matching is local to the editor.
+
+    static var previousHistoryImageHotkeyKeyCode: Int {
+        get { defaults.integer(forKey: "previousHistoryImageHotkeyKeyCode") }
+        set { defaults.set(newValue, forKey: "previousHistoryImageHotkeyKeyCode") }
+    }
+
+    static var previousHistoryImageHotkeyModifiers: Int {
+        get { defaults.integer(forKey: "previousHistoryImageHotkeyModifiers") }
+        set { defaults.set(newValue, forKey: "previousHistoryImageHotkeyModifiers") }
+    }
+
+    static var hasCustomPreviousHistoryImageHotkey: Bool {
+        defaults.object(forKey: "previousHistoryImageHotkeyKeyCode") != nil
+    }
+
+    static func clearPreviousHistoryImageHotkey() {
+        defaults.removeObject(forKey: "previousHistoryImageHotkeyKeyCode")
+        defaults.removeObject(forKey: "previousHistoryImageHotkeyModifiers")
+    }
+
+    static var nextHistoryImageHotkeyKeyCode: Int {
+        get { defaults.integer(forKey: "nextHistoryImageHotkeyKeyCode") }
+        set { defaults.set(newValue, forKey: "nextHistoryImageHotkeyKeyCode") }
+    }
+
+    static var nextHistoryImageHotkeyModifiers: Int {
+        get { defaults.integer(forKey: "nextHistoryImageHotkeyModifiers") }
+        set { defaults.set(newValue, forKey: "nextHistoryImageHotkeyModifiers") }
+    }
+
+    static var hasCustomNextHistoryImageHotkey: Bool {
+        defaults.object(forKey: "nextHistoryImageHotkeyKeyCode") != nil
+    }
+
+    static func clearNextHistoryImageHotkey() {
+        defaults.removeObject(forKey: "nextHistoryImageHotkeyKeyCode")
+        defaults.removeObject(forKey: "nextHistoryImageHotkeyModifiers")
     }
 
     static var penColor: Int {


### PR DESCRIPTION
## 变更内容
- 在截图编辑器内支持通过快捷键切换上一张和下一张历史截图，默认使用逗号和句号键
- 为历史截图切换增加设置页配置、快捷键冲突检测和默认值恢复
- 补齐相关本地化文案，并在裁剪和滚动截图期间阻止历史切换

## 验证
- bash scripts/compile-check.sh