### PR TITLE
fix: collapse translation config when provider switch is turned off

### DIFF
--- a/capcap/Settings/TranslationSettingsPane.swift
+++ b/capcap/Settings/TranslationSettingsPane.swift
@@ -410,6 +410,8 @@ private final class TranslationProviderCard: NSView {
             if config.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 setExpanded(true, animated: true)
             }
+        } else {
+            setExpanded(false, animated: true)
         }
         TranslationConfigStore.setEnabled(on, for: kind)
     }

--- a/capcap/Settings/UploadSettingsPane.swift
+++ b/capcap/Settings/UploadSettingsPane.swift
@@ -558,6 +558,7 @@ private final class ProviderCard: NSView {
             pendingTestToken = nil
             status = .untested
             logView.append(.info, L10n.uploadLogProviderDisabled)
+            setExpanded(false, animated: true)
         }
     }
 


### PR DESCRIPTION
## What's changed?
<img width="746" height="514" alt="Jun-21-2026 14-03-42" src="https://github.com/user-attachments/assets/68f75351-5fa9-48a9-b436-e352e5c7a40f" />

In the Settings panel's translation section, toggling a provider's enable switch ON expands its configuration fields, but toggling it OFF left those fields visible — the body never collapsed.


## Root cause

switchToggled() in capcap/Settings/TranslationSettingsPane.swift only handled the ON case (calling setExpanded(true,…) when the API key was empty). There was no branch for the OFF case, so the expanded body stayed open.

## Fix

Added an else branch that calls setExpanded(false, animated: true) when the switch is turned off, so the config body collapses with the same animation it uses to expand.
<img width="746" height="514" alt="Jun-21-2026 13-57-46" src="https://github.com/user-attachments/assets/7176a2ae-2063-4c03-8b5a-0bdde72ae252" />
