### PR TITLE
perf(capture): 将全屏预截图移出主线程，修复快捷键截图转圈卡顿

### DIFF
--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -63,6 +63,8 @@ class OverlayWindowController {
     private var escGlobalMonitor: Any?
     private var rightMouseLocalMonitor: Any?
     private var rightMouseGlobalMonitor: Any?
+    private var preparationEscLocalMonitor: Any?
+    private var preparationEscGlobalMonitor: Any?
     private var editController: EditWindowController?
     private var activeSelectionView: SelectionView?
     private var activeScreen: NSScreen?
@@ -88,6 +90,10 @@ class OverlayWindowController {
     private let suspendedDraft: SuspendedEditDraft?
     private let keepsEditorAcrossSpaces: Bool
     private var presentationScheduled = false
+    /// Bumped when a new prepare cycle starts or when cancelled mid-prepare so
+    /// stale background snapshot work never presents an overlay.
+    private var presentationGeneration = 0
+    private var isPreparingOverlay = false
 
     private struct ActiveEditorContext {
         let captureRect: CGRect
@@ -220,8 +226,109 @@ class OverlayWindowController {
     }
 
     private func prepareAndPresentOverlay() {
-        prepareScreenContext()
+        // Window list + screen metadata must be sampled on the main thread.
+        // Full-display CGWindowListCreateImage is expensive (multi‑MB per
+        // Retina / 5K screen) and used to run serially on the main thread,
+        // which blocked the run loop and produced the spinning wait cursor
+        // before any selection overlay appeared.
+        windowDetector.refresh()
 
+        let targets: [DisplayCaptureTarget] = NSScreen.screens.compactMap { screen in
+            guard let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+                return nil
+            }
+            return DisplayCaptureTarget(displayID: displayID, bounds: CGDisplayBounds(displayID))
+        }
+
+        presentationGeneration += 1
+        let generation = presentationGeneration
+        isPreparingOverlay = true
+        screenSnapshots.removeAll()
+        installPreparationCancelMonitors()
+
+        let prepareStarted = CFAbsoluteTimeGetCurrent()
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let captured = Self.captureScreenSnapshots(targets: targets)
+            let captureMs = (CFAbsoluteTimeGetCurrent() - prepareStarted) * 1000
+
+            DispatchQueue.main.async {
+                guard let self else { return }
+                // Cancelled or superseded by a newer prepare cycle.
+                guard generation == self.presentationGeneration, self.isPreparingOverlay else { return }
+
+                self.removePreparationCancelMonitors()
+                self.isPreparingOverlay = false
+                self.screenSnapshots = captured.images
+
+                DiagnosticLog.log(
+                    "overlay-prepare",
+                    "screen-snapshots-ready",
+                    metadata: [
+                        "displayCount": targets.count,
+                        "capturedCount": captured.images.count,
+                        "captureMs": String(format: "%.1f", captureMs),
+                        "perDisplayMs": captured.perDisplayMs
+                            .map { "\($0.key)=\(String(format: "%.1f", $0.value))" }
+                            .sorted()
+                            .joined(separator: ","),
+                    ]
+                )
+
+                self.finishPresentOverlayAfterPrepare()
+            }
+        }
+    }
+
+    private struct ScreenSnapshotCaptureResult {
+        let images: [CGDirectDisplayID: CGImage]
+        let perDisplayMs: [CGDirectDisplayID: Double]
+    }
+
+    private struct DisplayCaptureTarget {
+        let displayID: CGDirectDisplayID
+        let bounds: CGRect
+    }
+
+    /// Capture every display in parallel off the main thread.
+    private static func captureScreenSnapshots(
+        targets: [DisplayCaptureTarget]
+    ) -> ScreenSnapshotCaptureResult {
+        guard !targets.isEmpty else {
+            return ScreenSnapshotCaptureResult(images: [:], perDisplayMs: [:])
+        }
+
+        // Pre-capture all screen content before overlay panels appear,
+        // so transient menus and popups are preserved in the snapshot.
+        // Use CGWindowListCreateImage with .bestResolution so the image
+        // matches the display's effective resolution (not the native panel
+        // resolution), avoiding a visible scale shift on scaled displays.
+        let imagesBox = SnapshotDictionaryBox()
+        let timingBox = TimingDictionaryBox()
+
+        DispatchQueue.concurrentPerform(iterations: targets.count) { index in
+            let target = targets[index]
+            let started = CFAbsoluteTimeGetCurrent()
+            let image = CGWindowListCreateImage(
+                target.bounds,
+                .optionOnScreenOnly,
+                kCGNullWindowID,
+                .bestResolution
+            )
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - started) * 1000
+            timingBox.set(elapsedMs, for: target.displayID)
+            if let image {
+                imagesBox.set(image, for: target.displayID)
+            }
+        }
+
+        return ScreenSnapshotCaptureResult(
+            images: imagesBox.snapshot(),
+            perDisplayMs: timingBox.snapshot()
+        )
+    }
+
+    private func finishPresentOverlayAfterPrepare() {
         if Self.isRunningEventTrackingMode {
             Self.dismissActiveEventTrackingSurface()
             MainRunLoopScheduler.performInDefaultMode { [weak self] in
@@ -232,37 +339,53 @@ class OverlayWindowController {
         }
     }
 
-    private func prepareScreenContext() {
-        let screens = NSScreen.screens
-
-        // Snapshot visible windows before our overlays appear
-        windowDetector.refresh()
-
-        // Pre-capture all screen content before overlay panels appear,
-        // so transient menus and popups are preserved in the snapshot.
-        // Use CGWindowListCreateImage with .bestResolution so the image
-        // matches the display's effective resolution (not the native panel
-        // resolution), avoiding a visible scale shift on scaled displays.
-        screenSnapshots.removeAll()
-        for screen in screens {
-            if let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID {
-                let displayBounds = CGDisplayBounds(displayID)
-                if let image = CGWindowListCreateImage(
-                    displayBounds,
-                    .optionOnScreenOnly,
-                    kCGNullWindowID,
-                    .bestResolution
-                ) {
-                    screenSnapshots[displayID] = image
-                }
+    private func installPreparationCancelMonitors() {
+        removePreparationCancelMonitors()
+        preparationEscLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 {
+                self?.cancelDuringPreparation()
+                return nil
+            }
+            return event
+        }
+        preparationEscGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 {
+                self?.cancelDuringPreparation()
             }
         }
     }
 
+    private func removePreparationCancelMonitors() {
+        if let monitor = preparationEscLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            preparationEscLocalMonitor = nil
+        }
+        if let monitor = preparationEscGlobalMonitor {
+            NSEvent.removeMonitor(monitor)
+            preparationEscGlobalMonitor = nil
+        }
+    }
+
+    private func cancelDuringPreparation() {
+        guard isPreparingOverlay else { return }
+        presentationGeneration += 1
+        isPreparingOverlay = false
+        removePreparationCancelMonitors()
+        screenSnapshots.removeAll()
+        // Crosshair is only pushed once presentOverlay runs; skip the matching
+        // pop so cancel-during-prepare does not unbalance the cursor stack.
+        cursorPopped = true
+        tearDown()
+        onComplete(nil)
+        onRequestFocusReturn?()
+    }
+
     private func presentOverlay() {
         guard windows.isEmpty else { return }
-        // Create all overlay windows and pre-render their content before
-        // showing any of them, so there is no visible flash or zoom.
+        let presentStarted = CFAbsoluteTimeGetCurrent()
+
+        // Create all overlay windows and seed snapshot layers before showing
+        // any of them, so there is no visible flash or zoom.
         for screen in NSScreen.screens {
             let window = OverlayPanel(
                 contentRect: screen.frame,
@@ -285,12 +408,15 @@ class OverlayWindowController {
             selectionView.aspectRatio = usesAspectRatioSelection ? Self.persistedSelectionAspectRatio : nil
             if let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
                let snapshot = screenSnapshots[displayID] {
-                selectionView.backgroundSnapshot = NSImage(cgImage: snapshot, size: screen.frame.size)
+                selectionView.setBackgroundSnapshot(cgImage: snapshot, pointSize: screen.frame.size)
             }
             window.contentView = selectionView
 
             // Pre-render the snapshot into the backing store before the window
             // becomes visible, so the first on-screen frame already has content.
+            // Runs on the main thread but only after off-main capture completes,
+            // so the earlier multi-second beachball from CGWindowListCreateImage
+            // no longer blocks the run loop.
             selectionView.display()
 
             windows.append(window)
@@ -304,6 +430,15 @@ class OverlayWindowController {
         }
         windows.first?.makeKey()
         CATransaction.commit()
+
+        DiagnosticLog.log(
+            "overlay-prepare",
+            "overlay-presented",
+            metadata: [
+                "windowCount": windows.count,
+                "presentMs": String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - presentStarted) * 1000),
+            ]
+        )
 
         if presetImage == nil, suspendedDraft == nil {
             for case let selectionView as SelectionView in windows.compactMap(\.contentView) {
@@ -682,6 +817,10 @@ class OverlayWindowController {
     }
 
     func cancel() {
+        if isPreparingOverlay {
+            cancelDuringPreparation()
+            return
+        }
         editController?.tearDown()
         editController = nil
         tearDown()
@@ -730,6 +869,9 @@ class OverlayWindowController {
 
     private func tearDown() {
         ToastWindow.dismiss()
+
+        isPreparingOverlay = false
+        removePreparationCancelMonitors()
 
         if !cursorPopped {
             NSCursor.pop()
@@ -1279,6 +1421,44 @@ extension OverlayWindowController: SelectionViewDelegate {
         }
 
         return ScreenCapturer.crop(from: preSnapshot, captureRect: captureRect, screen: screen)
+    }
+}
+
+// MARK: - Thread-safe snapshot collectors
+
+/// Holds per-display CGImages produced by concurrent capture workers.
+private final class SnapshotDictionaryBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [CGDirectDisplayID: CGImage] = [:]
+
+    func set(_ image: CGImage, for displayID: CGDirectDisplayID) {
+        lock.lock()
+        values[displayID] = image
+        lock.unlock()
+    }
+
+    func snapshot() -> [CGDirectDisplayID: CGImage] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+/// Holds per-display capture timings from concurrent workers.
+private final class TimingDictionaryBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [CGDirectDisplayID: Double] = [:]
+
+    func set(_ milliseconds: Double, for displayID: CGDirectDisplayID) {
+        lock.lock()
+        values[displayID] = milliseconds
+        lock.unlock()
+    }
+
+    func snapshot() -> [CGDirectDisplayID: Double] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
     }
 }
 

--- a/capcap/Capture/SelectionView.swift
+++ b/capcap/Capture/SelectionView.swift
@@ -70,6 +70,12 @@ class SelectionView: NSView {
     /// Full-screen snapshot taken before overlays appear, preserving transient menus/popups.
     var backgroundSnapshot: NSImage?
 
+    /// Seeds the frozen desktop background from a CGImage produced by the
+    /// off-main-thread pre-capture path.
+    func setBackgroundSnapshot(cgImage: CGImage, pointSize: NSSize) {
+        backgroundSnapshot = NSImage(cgImage: cgImage, size: pointSize)
+    }
+
     // MARK: - Window Detection
 
     /// Set by OverlayWindowController so the view can detect windows under the cursor.


### PR DESCRIPTION
## Summary

- **问题**：按下截图快捷键后，选区 overlay 出现前会在主线程同步串行调用 `CGWindowListCreateImage(..., .bestResolution)` 抓取每块显示器的全屏快照；在高分辨率（如 5K）或系统繁忙时可能阻塞数秒，出现转圈（beachball），选区迟迟不可用。
- **修复**：将全屏预截图移到后台并行执行；截图完成后再回主线程呈现选区；准备阶段支持 Esc 取消；补充 prepare 耗时诊断日志。
- **影响范围**：`OverlayWindowController` 预截图/呈现路径、`SelectionView` 背景快照入口。产品语义不变（仍先冻屏再出选区，菜单/弹层可被捕获）。