### PR TITLE
feat(beautify): 透明背景预设与设置默认开启美化

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Beautify";
+"beautifyPresetTransparent" = "Transparent";
 "beautifyPresetPeachBlue" = "Peach Blue";
 "beautifyPresetMintTeal" = "Mint Teal";
 "beautifyPresetPeachPink" = "Peach Pink";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Neutral Gray";
 "beautifyPresetWallpaper" = "Wallpaper";
 "beautifyShadowEffect" = "Shadow Effect";
+"beautifyAutoToggleLabel" = "Open Editor with Beautify";
+"beautifyAutoToggleHint" = "Automatically apply the last beautify preset, padding, and shadow when the editor opens";
+"beautifyDefaultPresetLabel" = "Default Preset";
+"beautifyDefaultPaddingLabel" = "Default Padding";
 "textStrokeEffect" = "Stroke";
 "textCalloutEffect" = "Callout";
 "shapeFillEffect" = "Fill";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Embellir";
+"beautifyPresetTransparent" = "Transparent";
 "beautifyPresetPeachBlue" = "Pêche bleu";
 "beautifyPresetMintTeal" = "Menthe sarcelle";
 "beautifyPresetPeachPink" = "Pêche rose";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Gris neutre";
 "beautifyPresetWallpaper" = "Fond d'écran";
 "beautifyShadowEffect" = "Ombre";
+"beautifyAutoToggleLabel" = "Ouvrir l'éditeur avec Beautify";
+"beautifyAutoToggleHint" = "Applique automatiquement le dernier préréglage, le padding et l'ombre à l'ouverture de l'éditeur";
+"beautifyDefaultPresetLabel" = "Préréglage par défaut";
+"beautifyDefaultPaddingLabel" = "Marge par défaut";
 "textStrokeEffect" = "Contour";
 "textCalloutEffect" = "Annotation";
 "shapeFillEffect" = "Remplir";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "装飾";
+"beautifyPresetTransparent" = "透明";
 "beautifyPresetPeachBlue" = "ピーチブルー";
 "beautifyPresetMintTeal" = "ミントティール";
 "beautifyPresetPeachPink" = "ピーチピンク";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "ニュートラルグレー";
 "beautifyPresetWallpaper" = "壁紙";
 "beautifyShadowEffect" = "影効果";
+"beautifyAutoToggleLabel" = "エディタ起動時に美化を有効化";
+"beautifyAutoToggleHint" = "エディタを開くと前回の美化プリセット・余白・影を自動適用します";
+"beautifyDefaultPresetLabel" = "デフォルトのプリセット";
+"beautifyDefaultPaddingLabel" = "デフォルトの余白";
 "textStrokeEffect" = "縁取り";
 "textCalloutEffect" = "吹き出し";
 "shapeFillEffect" = "塗りつぶし";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "꾸미기";
+"beautifyPresetTransparent" = "투명";
 "beautifyPresetPeachBlue" = "피치 블루";
 "beautifyPresetMintTeal" = "민트 틸";
 "beautifyPresetPeachPink" = "피치 핑크";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "뉴트럴 그레이";
 "beautifyPresetWallpaper" = "배경화면";
 "beautifyShadowEffect" = "그림자";
+"beautifyAutoToggleLabel" = "편집기 열 때 미화 자동 적용";
+"beautifyAutoToggleHint" = "편집기를 열면 마지막 미화 프리셋, 여백, 그림자를 자동으로 적용합니다";
+"beautifyDefaultPresetLabel" = "기본 프리셋";
+"beautifyDefaultPaddingLabel" = "기본 여백";
 "textStrokeEffect" = "테두리";
 "textCalloutEffect" = "콜아웃";
 "shapeFillEffect" = "채우기";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Оформление";
+"beautifyPresetTransparent" = "Прозрачный";
 "beautifyPresetPeachBlue" = "Персиково-синий";
 "beautifyPresetMintTeal" = "Мятно-бирюзовый";
 "beautifyPresetPeachPink" = "Персиково-розовый";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Нейтральный серый";
 "beautifyPresetWallpaper" = "Обои";
 "beautifyShadowEffect" = "Тень";
+"beautifyAutoToggleLabel" = "Открывать редактор с Beautify";
+"beautifyAutoToggleHint" = "Автоматически применять последний пресет, отступ и тень при открытии редактора";
+"beautifyDefaultPresetLabel" = "Пресет по умолчанию";
+"beautifyDefaultPaddingLabel" = "Отступ по умолчанию";
 "textStrokeEffect" = "Обводка";
 "textCalloutEffect" = "Выноска";
 "shapeFillEffect" = "Заливка";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Làm đẹp";
+"beautifyPresetTransparent" = "Trong suốt";
 "beautifyPresetPeachBlue" = "Hồng đào xanh";
 "beautifyPresetMintTeal" = "Bạc hà lam ngọc";
 "beautifyPresetPeachPink" = "Hồng đào";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Xám trung tính";
 "beautifyPresetWallpaper" = "Hình nền";
 "beautifyShadowEffect" = "Hiệu ứng bóng";
+"beautifyAutoToggleLabel" = "Mở trình chỉnh sửa với Beautify";
+"beautifyAutoToggleHint" = "Tự động áp dụng preset, lề và bóng đã dùng lần trước khi mở trình chỉnh sửa";
+"beautifyDefaultPresetLabel" = "Preset mặc định";
+"beautifyDefaultPaddingLabel" = "Lề mặc định";
 "textStrokeEffect" = "Viền chữ";
 "textCalloutEffect" = "Chú thích";
 "shapeFillEffect" = "Tô màu";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "美化";
+"beautifyPresetTransparent" = "透明";
 "beautifyPresetPeachBlue" = "粉蓝";
 "beautifyPresetMintTeal" = "薄荷青";
 "beautifyPresetPeachPink" = "桃粉";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "中性灰";
 "beautifyPresetWallpaper" = "壁纸";
 "beautifyShadowEffect" = "阴影效果";
+"beautifyAutoToggleLabel" = "进入编辑器默认开启美化";
+"beautifyAutoToggleHint" = "打开编辑器时自动应用上次的美化预设、边距和阴影";
+"beautifyDefaultPresetLabel" = "默认预设";
+"beautifyDefaultPaddingLabel" = "默认边距";
 "textStrokeEffect" = "描边";
 "textCalloutEffect" = "标注";
 "shapeFillEffect" = "填充";

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "美化";
+"beautifyPresetTransparent" = "透明";
 "beautifyPresetPeachBlue" = "蜜桃藍";
 "beautifyPresetMintTeal" = "薄荷青";
 "beautifyPresetPeachPink" = "蜜桃粉";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "中性灰";
 "beautifyPresetWallpaper" = "桌布";
 "beautifyShadowEffect" = "陰影效果";
+"beautifyAutoToggleLabel" = "進入編輯器預設開啟美化";
+"beautifyAutoToggleHint" = "開啟編輯器時自動套用上次的美化預設、邊距與陰影";
+"beautifyDefaultPresetLabel" = "預設樣式";
+"beautifyDefaultPaddingLabel" = "預設邊距";
 "textStrokeEffect" = "描邊";
 "textCalloutEffect" = "標註";
 "shapeFillEffect" = "填充";

--- a/capcap/Editor/BeautifyContainerView.swift
+++ b/capcap/Editor/BeautifyContainerView.swift
@@ -126,8 +126,11 @@ final class BeautifyContainerView: NSView {
         let outerRect = CGRect(origin: .zero, size: bounds.size)
         let innerRect = canvasView.frame
 
-        // 1. Background
-        if preset.isWallpaper, let wp = wallpaperImage {
+        // 1. Background — transparent uses a checkerboard so empty padding
+        // and rounded corners are visible; export stays pure alpha.
+        if preset.isTransparent {
+            BeautifyRenderer.drawCheckerboard(in: outerRect)
+        } else if preset.isWallpaper, let wp = wallpaperImage {
             BeautifyRenderer.drawWallpaperBackground(in: outerRect, wallpaper: wp)
         } else {
             BeautifyRenderer.drawBackground(in: outerRect, preset: preset)

--- a/capcap/Editor/BeautifyPreset.swift
+++ b/capcap/Editor/BeautifyPreset.swift
@@ -7,19 +7,41 @@ struct BeautifyPreset: Equatable {
     let endColor: NSColor
     let angleDegrees: CGFloat
     let isWallpaper: Bool
+    let isTransparent: Bool
 
-    init(id: String, displayName: String, startColor: NSColor, endColor: NSColor, angleDegrees: CGFloat, isWallpaper: Bool = false) {
+    init(
+        id: String,
+        displayName: String,
+        startColor: NSColor,
+        endColor: NSColor,
+        angleDegrees: CGFloat,
+        isWallpaper: Bool = false,
+        isTransparent: Bool = false
+    ) {
         self.id = id
         self.displayName = displayName
         self.startColor = startColor
         self.endColor = endColor
         self.angleDegrees = angleDegrees
         self.isWallpaper = isWallpaper
+        self.isTransparent = isTransparent
     }
 
     static func == (lhs: BeautifyPreset, rhs: BeautifyPreset) -> Bool {
         lhs.id == rhs.id
     }
+
+    /// Pure alpha background: export keeps transparent padding and rounded
+    /// corners; live preview draws a checkerboard so the empty areas stay
+    /// visible in the editor.
+    static let transparent = BeautifyPreset(
+        id: "transparent",
+        displayName: L10n.beautifyPresetTransparent,
+        startColor: .clear,
+        endColor: .clear,
+        angleDegrees: 0,
+        isTransparent: true
+    )
 
     static let wallpaper = BeautifyPreset(
         id: "wallpaper",
@@ -31,6 +53,7 @@ struct BeautifyPreset: Equatable {
     )
 
     static let defaults: [BeautifyPreset] = [
+        transparent,
         BeautifyPreset(
             id: "peach-blue",
             displayName: L10n.beautifyPresetPeachBlue,

--- a/capcap/Editor/BeautifyRenderer.swift
+++ b/capcap/Editor/BeautifyRenderer.swift
@@ -182,15 +182,45 @@ enum BeautifyRenderer {
     // MARK: - Drawing primitives
 
     /// Draws a linear gradient across `outerRect` using the preset colors and angle.
-    /// For wallpaper presets the area is left clear (caller draws wallpaper separately).
+    /// Wallpaper and transparent presets leave the area empty (caller draws
+    /// wallpaper / checkerboard separately for preview; export clears alpha).
     static func drawBackground(in outerRect: CGRect, preset: BeautifyPreset) {
-        if preset.isWallpaper { return }
+        if preset.isWallpaper || preset.isTransparent { return }
         guard let gradient = NSGradient(starting: preset.startColor, ending: preset.endColor) else {
             preset.startColor.setFill()
             outerRect.fill()
             return
         }
         gradient.draw(in: outerRect, angle: preset.angleDegrees)
+    }
+
+    /// Checkerboard used only in the editor preview so transparent padding
+    /// and rounded corners stay visible. Never baked into exported images.
+    static func drawCheckerboard(in rect: CGRect, square: CGFloat = 14) {
+        guard square > 0, rect.width > 0, rect.height > 0 else { return }
+        var y = rect.minY
+        var row = 0
+        while y < rect.maxY {
+            var x = rect.minX
+            var column = 0
+            while x < rect.maxX {
+                let isLight = (row + column).isMultiple(of: 2)
+                (isLight
+                    ? NSColor(calibratedWhite: 0.88, alpha: 1)
+                    : NSColor(calibratedWhite: 0.72, alpha: 1)
+                ).setFill()
+                NSRect(
+                    x: x,
+                    y: y,
+                    width: min(square, rect.maxX - x),
+                    height: min(square, rect.maxY - y)
+                ).fill()
+                x += square
+                column += 1
+            }
+            y += square
+            row += 1
+        }
     }
 
     /// Draws a wallpaper image as background, aspect-fill centered in `outerRect`.
@@ -368,8 +398,11 @@ enum BeautifyRenderer {
 
         let cg = ctx.cgContext
 
-        // 1. Background
-        if preset.isWallpaper, let wp = wallpaperImage {
+        // 1. Background — transparent presets keep pure alpha (no desktop,
+        // no wallpaper, no gradient). Checkerboard is preview-only.
+        if preset.isTransparent {
+            cg.clear(outerRect)
+        } else if preset.isWallpaper, let wp = wallpaperImage {
             drawWallpaperBackground(in: outerRect, wallpaper: wp)
         } else {
             drawBackground(in: outerRect, preset: preset)

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -225,6 +225,9 @@ class EditWindowController {
 
         showToolbar()
         updateHistoryButtons(canUndo: canvas.canUndo, canRedo: canvas.canRedo)
+        if Defaults.beautifyAutoEnabled {
+            activateBeautify()
+        }
         bringEditorToFront()
     }
 
@@ -5493,7 +5496,9 @@ private class BeautifySwatchView: NSView {
         NSGraphicsContext.saveGraphicsState()
         clipPath.addClip()
 
-        if preset.isWallpaper, let wpImage = wallpaperThumbnail {
+        if preset.isTransparent {
+            BeautifyRenderer.drawCheckerboard(in: circleRect, square: 4)
+        } else if preset.isWallpaper, let wpImage = wallpaperThumbnail {
             wpImage.draw(in: circleRect, from: .zero, operation: .sourceOver, fraction: 1.0)
         } else if preset.isWallpaper {
             // Fallback: draw a landscape-like icon

--- a/capcap/Settings/SettingsView.swift
+++ b/capcap/Settings/SettingsView.swift
@@ -93,6 +93,18 @@ class SettingsView: NSView {
     private var windowShadowSizeTitleLabel: NSTextField!
     private var windowShadowSizeHintLabel: NSTextField!
 
+    // Beautify defaults card
+    private var beautifyAutoSwitch: NSSwitch!
+    private var beautifyAutoTitleLabel: NSTextField!
+    private var beautifyAutoSubtitleLabel: NSTextField?
+    private var beautifyPresetTitleLabel: NSTextField!
+    private var beautifyPaddingTitleLabel: NSTextField!
+    private var beautifyPaddingValueLabel: NSTextField!
+    private var beautifyPaddingSlider: NSSlider!
+    private var beautifyShadowSwitch: NSSwitch!
+    private var beautifyShadowTitleLabel: NSTextField!
+    private var beautifyPresetSwatches: [BeautifySettingsSwatchView] = []
+
     // Screenshot shortcut card
     private var shortcutTitleLabel: NSTextField!
     private var shortcutField: NSTextField!
@@ -720,6 +732,8 @@ class SettingsView: NSView {
 
         buildWindowShadowCard(into: stack)
 
+        buildBeautifyDefaultsCard(into: stack)
+
         buildHistoryAndCountdownCards(into: stack)
 
         let filenameCard = FilenameRuleCard()
@@ -823,6 +837,112 @@ class SettingsView: NSView {
         windowShadowSizeTitleLabel?.textColor = NSColor.white.withAlphaComponent(on ? 0.94 : 0.4)
         windowShadowSizeValueLabel?.textColor = NSColor.white.withAlphaComponent(on ? 0.88 : 0.4)
         windowShadowPreview?.isEffectEnabled = on
+    }
+
+    /// Default beautify behaviour when the annotation editor opens: optional
+    /// auto-enable plus the shared last-used preset / padding / shadow.
+    private func buildBeautifyDefaultsCard(into stack: NSStackView) {
+        let card = CardView()
+        let inner = NSStackView()
+        inner.orientation = .vertical
+        inner.alignment = .leading
+        inner.spacing = 10
+        inner.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(inner)
+        pin(inner, to: card, insets: NSEdgeInsets(top: 4, left: 14, bottom: 14, right: 14))
+
+        let toggle = makeToggleRow(
+            title: L10n.beautifyAutoToggleLabel,
+            subtitle: L10n.beautifyAutoToggleHint,
+            isOn: Defaults.beautifyAutoEnabled,
+            action: #selector(beautifyAutoToggled(_:))
+        )
+        beautifyAutoTitleLabel = toggle.title
+        beautifyAutoSubtitleLabel = toggle.subtitle
+        beautifyAutoSwitch = toggle.toggle
+        inner.addArrangedSubview(toggle.row)
+        toggle.row.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let divider = rowDivider()
+        inner.addArrangedSubview(divider)
+        divider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        beautifyPresetTitleLabel = primaryLabel(L10n.beautifyDefaultPresetLabel)
+        inner.addArrangedSubview(beautifyPresetTitleLabel)
+
+        let swatchRow = NSStackView()
+        swatchRow.orientation = .horizontal
+        swatchRow.alignment = .centerY
+        swatchRow.spacing = 8
+        swatchRow.translatesAutoresizingMaskIntoConstraints = false
+
+        let selectedID = Defaults.lastBeautifyPresetID ?? BeautifyPreset.defaultPreset.id
+        beautifyPresetSwatches = []
+        for preset in BeautifyPreset.defaults {
+            let swatch = BeautifySettingsSwatchView(preset: preset)
+            swatch.isSelected = (preset.id == selectedID)
+            swatch.target = self
+            swatch.action = #selector(beautifyPresetSwatchClicked(_:))
+            swatch.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                swatch.widthAnchor.constraint(equalToConstant: 24),
+                swatch.heightAnchor.constraint(equalToConstant: 24),
+            ])
+            if preset.isWallpaper, let screen = NSScreen.main {
+                BeautifyRenderer.loadWallpaperImage(for: screen) { [weak swatch] image in
+                    swatch?.wallpaperThumbnail = image
+                }
+            }
+            swatchRow.addArrangedSubview(swatch)
+            beautifyPresetSwatches.append(swatch)
+        }
+        inner.addArrangedSubview(swatchRow)
+
+        let paddingHeader = NSStackView()
+        paddingHeader.orientation = .horizontal
+        paddingHeader.alignment = .firstBaseline
+        paddingHeader.spacing = 8
+        paddingHeader.translatesAutoresizingMaskIntoConstraints = false
+
+        beautifyPaddingTitleLabel = primaryLabel(L10n.beautifyDefaultPaddingLabel)
+        paddingHeader.addArrangedSubview(beautifyPaddingTitleLabel)
+        paddingHeader.addArrangedSubview(flexSpacer())
+
+        beautifyPaddingValueLabel = NSTextField(labelWithString: "\(Int(Defaults.lastBeautifyPadding.rounded()))")
+        beautifyPaddingValueLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .semibold)
+        beautifyPaddingValueLabel.textColor = NSColor.white.withAlphaComponent(0.88)
+        paddingHeader.addArrangedSubview(beautifyPaddingValueLabel)
+
+        inner.addArrangedSubview(paddingHeader)
+        paddingHeader.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let paddingSlider = NSSlider(
+            value: Defaults.lastBeautifyPadding,
+            minValue: Double(BeautifyRenderer.paddingSliderMin),
+            maxValue: Double(BeautifyRenderer.paddingSliderMax),
+            target: self,
+            action: #selector(beautifyPaddingChanged(_:))
+        )
+        paddingSlider.controlSize = .small
+        paddingSlider.isContinuous = true
+        paddingSlider.translatesAutoresizingMaskIntoConstraints = false
+        beautifyPaddingSlider = paddingSlider
+        inner.addArrangedSubview(paddingSlider)
+        paddingSlider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let shadowToggle = makeToggleRow(
+            title: L10n.beautifyShadowEffect,
+            subtitle: nil,
+            isOn: Defaults.lastBeautifyShadowEnabled,
+            action: #selector(beautifyShadowToggled(_:))
+        )
+        beautifyShadowTitleLabel = shadowToggle.title
+        beautifyShadowSwitch = shadowToggle.toggle
+        inner.addArrangedSubview(shadowToggle.row)
+        shadowToggle.row.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        stack.addArrangedSubview(card)
+        card.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
     }
 
     private func updateHistoryCacheControlsEnabled() {
@@ -2928,6 +3048,26 @@ class SettingsView: NSView {
         windowShadowPreview?.shadowSize = CGFloat(Defaults.windowShadowSize)
     }
 
+    @objc private func beautifyAutoToggled(_ sender: NSSwitch) {
+        Defaults.beautifyAutoEnabled = sender.state == .on
+    }
+
+    @objc private func beautifyPresetSwatchClicked(_ sender: BeautifySettingsSwatchView) {
+        Defaults.lastBeautifyPresetID = sender.preset.id
+        for swatch in beautifyPresetSwatches {
+            swatch.isSelected = (swatch.preset.id == sender.preset.id)
+        }
+    }
+
+    @objc private func beautifyPaddingChanged(_ sender: NSSlider) {
+        Defaults.lastBeautifyPadding = sender.doubleValue
+        beautifyPaddingValueLabel?.stringValue = "\(Int(Defaults.lastBeautifyPadding.rounded()))"
+    }
+
+    @objc private func beautifyShadowToggled(_ sender: NSSwitch) {
+        Defaults.lastBeautifyShadowEnabled = sender.state == .on
+    }
+
     @objc private func launchAtLoginToggled(_ sender: NSSwitch) {
         let enable = sender.state == .on
         let ok = LaunchAtLogin.setEnabled(enable)
@@ -4775,6 +4915,20 @@ class SettingsView: NSView {
         windowShadowSubtitleLabel?.stringValue = L10n.windowShadowToggleHint
         windowShadowSizeTitleLabel?.stringValue = L10n.windowShadowSizeLabel
         windowShadowSizeHintLabel?.stringValue = L10n.windowShadowSizeHint
+        beautifyAutoTitleLabel?.stringValue = L10n.beautifyAutoToggleLabel
+        beautifyAutoSubtitleLabel?.stringValue = L10n.beautifyAutoToggleHint
+        beautifyPresetTitleLabel?.stringValue = L10n.beautifyDefaultPresetLabel
+        beautifyPaddingTitleLabel?.stringValue = L10n.beautifyDefaultPaddingLabel
+        beautifyShadowTitleLabel?.stringValue = L10n.beautifyShadowEffect
+        beautifyAutoSwitch?.state = Defaults.beautifyAutoEnabled ? .on : .off
+        beautifyPaddingSlider?.doubleValue = Defaults.lastBeautifyPadding
+        beautifyPaddingValueLabel?.stringValue = "\(Int(Defaults.lastBeautifyPadding.rounded()))"
+        beautifyShadowSwitch?.state = Defaults.lastBeautifyShadowEnabled ? .on : .off
+        let beautifySelectedID = Defaults.lastBeautifyPresetID ?? BeautifyPreset.defaultPreset.id
+        for swatch in beautifyPresetSwatches {
+            swatch.isSelected = (swatch.preset.id == beautifySelectedID)
+            swatch.needsDisplay = true
+        }
         countdownTitleLabel?.stringValue = L10n.countdownLabel
         countdownHintLabel?.stringValue = L10n.countdownHint
         countdownValueLabel?.stringValue = "\(Defaults.countdownSeconds)\(L10n.countdownSecondsSuffix)"
@@ -5418,6 +5572,83 @@ private final class SettingsTickSlider: NSControl {
         let steps = ((clamped - minValue) / stepValue).rounded()
         let snapped = minValue + steps * stepValue
         return min(max(snapped, minValue), maxValue)
+    }
+}
+
+// MARK: - Beautify settings swatch
+
+/// Compact circular preset swatch used in the general settings beautify card.
+private final class BeautifySettingsSwatchView: NSView {
+    let preset: BeautifyPreset
+    weak var target: AnyObject?
+    var action: Selector?
+
+    var isSelected: Bool = false {
+        didSet { needsDisplay = true }
+    }
+
+    var wallpaperThumbnail: NSImage? {
+        didSet { needsDisplay = true }
+    }
+
+    init(preset: BeautifyPreset) {
+        self.preset = preset
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        if let action {
+            _ = target?.perform(action, with: self)
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let inset: CGFloat = isSelected ? 1 : 2
+        let circleRect = bounds.insetBy(dx: inset, dy: inset)
+        let clipPath = NSBezierPath(ovalIn: circleRect)
+        NSGraphicsContext.saveGraphicsState()
+        clipPath.addClip()
+
+        if preset.isTransparent {
+            BeautifyRenderer.drawCheckerboard(in: circleRect, square: 4)
+        } else if preset.isWallpaper, let wpImage = wallpaperThumbnail {
+            wpImage.draw(in: circleRect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        } else if preset.isWallpaper {
+            NSColor(red: 0.4, green: 0.65, blue: 0.45, alpha: 1).setFill()
+            circleRect.fill()
+            let sky = NSRect(
+                x: circleRect.origin.x,
+                y: circleRect.midY,
+                width: circleRect.width,
+                height: circleRect.height / 2
+            )
+            NSColor(red: 0.55, green: 0.75, blue: 0.92, alpha: 1).setFill()
+            sky.fill()
+        } else if let gradient = NSGradient(starting: preset.startColor, ending: preset.endColor) {
+            gradient.draw(in: circleRect, angle: preset.angleDegrees)
+        } else {
+            preset.startColor.setFill()
+            circleRect.fill()
+        }
+        NSGraphicsContext.restoreGraphicsState()
+
+        let border = NSBezierPath(ovalIn: circleRect)
+        AdaptiveChrome.border.setStroke()
+        border.lineWidth = 0.5
+        border.stroke()
+
+        if isSelected {
+            let ring = NSBezierPath(ovalIn: bounds)
+            NSColor(calibratedRed: 0, green: 0.83, blue: 0.42, alpha: 1).setStroke()
+            ring.lineWidth = 2
+            ring.stroke()
+        }
     }
 }
 

--- a/capcap/Utilities/Defaults.swift
+++ b/capcap/Utilities/Defaults.swift
@@ -373,6 +373,7 @@ enum L10n {
 
     // Beautify
     static var beautify: String { s("beautify") }
+    static var beautifyPresetTransparent: String { s("beautifyPresetTransparent") }
     static var beautifyPresetPeachBlue: String { s("beautifyPresetPeachBlue") }
     static var beautifyPresetMintTeal: String { s("beautifyPresetMintTeal") }
     static var beautifyPresetPeachPink: String { s("beautifyPresetPeachPink") }
@@ -383,6 +384,10 @@ enum L10n {
     static var beautifyPresetNeutralGray: String { s("beautifyPresetNeutralGray") }
     static var beautifyPresetWallpaper: String { s("beautifyPresetWallpaper") }
     static var beautifyShadowEffect: String { s("beautifyShadowEffect") }
+    static var beautifyAutoToggleLabel: String { s("beautifyAutoToggleLabel") }
+    static var beautifyAutoToggleHint: String { s("beautifyAutoToggleHint") }
+    static var beautifyDefaultPresetLabel: String { s("beautifyDefaultPresetLabel") }
+    static var beautifyDefaultPaddingLabel: String { s("beautifyDefaultPaddingLabel") }
 
     // Text tool
     static var textStrokeEffect: String { s("textStrokeEffect") }
@@ -1656,6 +1661,20 @@ struct Defaults {
         }
         set {
             defaults.set(newValue, forKey: "lastBeautifyShadowEnabled")
+        }
+    }
+
+    /// When true, the annotation editor opens with beautify already active,
+    /// using the last-used preset / padding / shadow settings.
+    static var beautifyAutoEnabled: Bool {
+        get {
+            if defaults.object(forKey: "beautifyAutoEnabled") == nil {
+                return false
+            }
+            return defaults.bool(forKey: "beautifyAutoEnabled")
+        }
+        set {
+            defaults.set(newValue, forKey: "beautifyAutoEnabled")
         }
     }
 


### PR DESCRIPTION
## Summary
- 新增透明美化背景预设（导出纯 alpha、预览棋盘格）
- 设置中支持默认开启美化，以及预设 / 边距 / 阴影配置

## Test plan
- [ ] 打开美化工具，选择透明背景预设，确认预览为棋盘格
- [ ] 导出/保存后图片背景为透明
- [ ] 在设置中开启「默认开启美化」，新截图进入编辑器时自动进入美化
- [ ] 调整默认预设、边距、阴影后，确认新会话生效