### PR TITLE
feat(save): 截图保存默认询问位置，设置中可关闭直存

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "Save paths";
-"savePathSubtitle" = "Screenshots and recordings save here without asking for a destination";
+"savePathSubtitle" = "Default locations for screenshots and recordings";
+"askSaveLocationLabel" = "Ask for save location";
+"askSaveLocationHint" = "Show a save dialog when saving screenshots; turn off to save directly to the screenshot path";
 "autoRevealSavedFilesLabel" = "Show in Finder";
 "autoRevealSavedFilesHint" = "Select the saved screenshot or recording in Finder after a successful save";
 "recordingSavePathLabel" = "Recording save path";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "Emplacements d'enregistrement";
-"savePathSubtitle" = "Les captures et enregistrements sont sauvegardés ici sans demander de destination";
+"savePathSubtitle" = "Emplacements par défaut des captures et enregistrements";
+"askSaveLocationLabel" = "Demander l'emplacement";
+"askSaveLocationHint" = "Afficher une boîte de dialogue pour les captures ; désactiver pour enregistrer directement";
 "autoRevealSavedFilesLabel" = "Afficher dans le Finder";
 "autoRevealSavedFilesHint" = "Sélectionner la capture ou l'enregistrement sauvegardé dans Finder après un enregistrement réussi";
 "recordingSavePathLabel" = "Chemin d'enregistrement";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "保存先";
-"savePathSubtitle" = "スクリーンショットと録画は保存先を確認せず、ここへ保存されます";
+"savePathSubtitle" = "スクリーンショットと録画のデフォルト保存先";
+"askSaveLocationLabel" = "保存先を確認";
+"askSaveLocationHint" = "スクリーンショット保存時にダイアログで場所を選ぶ。オフにすると保存先へ直接保存";
 "autoRevealSavedFilesLabel" = "Finder に表示";
 "autoRevealSavedFilesHint" = "保存に成功したスクリーンショットまたは録画を Finder で選択します";
 "recordingSavePathLabel" = "録画の保存先";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "저장 경로";
-"savePathSubtitle" = "스크린샷과 녹화는 저장 위치를 묻지 않고 여기에 저장됩니다";
+"savePathSubtitle" = "스크린샷과 녹화의 기본 저장 위치";
+"askSaveLocationLabel" = "저장 위치 묻기";
+"askSaveLocationHint" = "스크린샷 저장 시 대화상자로 위치를 선택합니다. 끄면 스크린샷 경로에 바로 저장";
 "autoRevealSavedFilesLabel" = "Finder에 표시";
 "autoRevealSavedFilesHint" = "저장 성공 후 Finder에서 저장된 스크린샷 또는 녹화를 선택합니다";
 "recordingSavePathLabel" = "녹화 저장 경로";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "Пути сохранения";
-"savePathSubtitle" = "Снимки и записи сохраняются сюда без запроса папки назначения";
+"savePathSubtitle" = "Пути по умолчанию для снимков и записей";
+"askSaveLocationLabel" = "Спрашивать путь сохранения";
+"askSaveLocationHint" = "Показывать диалог при сохранении снимка; выключите, чтобы сохранять сразу в путь снимков";
 "autoRevealSavedFilesLabel" = "Показать в Finder";
 "autoRevealSavedFilesHint" = "Выбирать сохранённый снимок или запись в Finder после успешного сохранения";
 "recordingSavePathLabel" = "Путь для записей";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "Đường dẫn lưu";
-"savePathSubtitle" = "Ảnh chụp và bản ghi được lưu tại đây mà không hỏi vị trí đích";
+"savePathSubtitle" = "Vị trí lưu mặc định cho ảnh chụp và bản ghi";
+"askSaveLocationLabel" = "Hỏi vị trí lưu";
+"askSaveLocationHint" = "Hiện hộp thoại khi lưu ảnh chụp; tắt để lưu thẳng vào đường dẫn ảnh chụp";
 "autoRevealSavedFilesLabel" = "Hiển thị trong Finder";
 "autoRevealSavedFilesHint" = "Chọn ảnh chụp hoặc bản ghi đã lưu trong Finder sau khi lưu thành công";
 "recordingSavePathLabel" = "Đường dẫn lưu bản ghi";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "保存路径";
-"savePathSubtitle" = "截图和录制会直接保存到这些路径，不再询问保存位置";
+"savePathSubtitle" = "配置截图和录制的默认保存位置";
+"askSaveLocationLabel" = "询问保存位置";
+"askSaveLocationHint" = "保存截图时弹出对话框选择位置，关闭后直接保存到截图路径";
 "autoRevealSavedFilesLabel" = "在 Finder 中显示";
 "autoRevealSavedFilesHint" = "保存成功后，在 Finder 中选中刚保存的截图或录制";
 "recordingSavePathLabel" = "录制保存路径";

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -548,7 +548,9 @@
 
 /* Save paths */
 "savePathTitle" = "儲存路徑";
-"savePathSubtitle" = "截圖和錄製會直接儲存到這些路徑，不再詢問儲存位置";
+"savePathSubtitle" = "設定截圖和錄製的預設儲存位置";
+"askSaveLocationLabel" = "詢問儲存位置";
+"askSaveLocationHint" = "儲存截圖時彈出對話框選擇位置，關閉後直接儲存到截圖路徑";
 "autoRevealSavedFilesLabel" = "在 Finder 中顯示";
 "autoRevealSavedFilesHint" = "儲存成功後，在 Finder 中選取剛儲存的截圖或錄製";
 "recordingSavePathLabel" = "錄製儲存路徑";

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -1634,6 +1634,32 @@ class EditWindowController {
     private func save() {
         canvasView?.commitActiveTextEditing()
         guard let finalImage = currentCompositeImage() else { return }
+        let quality = Defaults.screenshotSaveQuality
+
+        if Defaults.askSaveLocation {
+            let suggestedName = FilenameTemplate.imageFileName(
+                for: finalImage,
+                fileExtension: quality.fileExtension,
+                consumeCounters: false
+            )
+            promptForScreenshotSaveLocation(suggestedName: suggestedName) { [weak self] chosen in
+                guard let self else { return }
+                guard let chosen else {
+                    self.bringEditorToFront()
+                    return
+                }
+                self.finishSave(image: finalImage, destinationOverride: chosen)
+            }
+            return
+        }
+
+        finishSave(image: finalImage, destinationOverride: nil)
+    }
+
+    /// Encode and write the screenshot. When `destinationOverride` is set (user
+    /// picked a path in the save panel), write there; otherwise create a unique
+    /// file under the configured screenshot directory.
+    private func finishSave(image finalImage: NSImage, destinationOverride: URL?) {
         let targetScreen = screen
         let focusReturn = onRequestFocusReturn
         let quality = Defaults.screenshotSaveQuality
@@ -1656,15 +1682,24 @@ class EditWindowController {
                 ToastWindow.show(message: L10n.screenshotCompressionFailed, on: targetScreen, duration: 3.0)
             case .success(let output):
                 do {
-                    let filename = FilenameTemplate.imageFileName(
-                        for: finalImage,
-                        fileExtension: output.fileExtension,
-                        imageSize: output.pixelSize
-                    )
-                    let destination = try SaveDestination.uniqueFile(
-                        in: Defaults.screenshotSaveDirectory,
-                        fileName: filename
-                    )
+                    let destination: URL
+                    if let destinationOverride {
+                        destination = destinationOverride
+                        try FileManager.default.createDirectory(
+                            at: destination.deletingLastPathComponent(),
+                            withIntermediateDirectories: true
+                        )
+                    } else {
+                        let filename = FilenameTemplate.imageFileName(
+                            for: finalImage,
+                            fileExtension: output.fileExtension,
+                            imageSize: output.pixelSize
+                        )
+                        destination = try SaveDestination.uniqueFile(
+                            in: Defaults.screenshotSaveDirectory,
+                            fileName: filename
+                        )
+                    }
                     try output.data.write(to: destination, options: .atomic)
                     let directoryPath = SaveDestination.displayPath(destination.deletingLastPathComponent())
                     ToastWindow.show(message: L10n.screenshotSaved(to: directoryPath), on: targetScreen)
@@ -1684,6 +1719,35 @@ class EditWindowController {
             if shouldReturnFocus {
                 focusReturn?()
             }
+        }
+    }
+
+    /// Save panel for screenshots. Presented as a sheet on the overlay when
+    /// possible so it appears above the capture chrome. Cancel keeps the editor open.
+    private func promptForScreenshotSaveLocation(
+        suggestedName: String,
+        completion: @escaping (URL?) -> Void
+    ) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+        panel.directoryURL = Defaults.screenshotSaveDirectory
+        panel.nameFieldStringValue = suggestedName
+
+        let finish: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .OK, let url = panel.url else {
+                completion(nil)
+                return
+            }
+            completion(url)
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        if let hostWindow = hostSelectionView?.window {
+            panel.beginSheetModal(for: hostWindow, completionHandler: finish)
+        } else {
+            panel.begin(completionHandler: finish)
         }
     }
 

--- a/capcap/Settings/SettingsView.swift
+++ b/capcap/Settings/SettingsView.swift
@@ -298,6 +298,9 @@ class SettingsView: NSView {
     private var screenshotQualityClipboardPopup: NSPopUpButton!
     private var savePathTitleLabel: NSTextField!
     private var savePathSubtitleLabel: NSTextField!
+    private var askSaveLocationTitleLabel: NSTextField!
+    private var askSaveLocationHintLabel: NSTextField?
+    private var askSaveLocationSwitch: NSSwitch!
     private var autoRevealSavedFilesTitleLabel: NSTextField!
     private var autoRevealSavedFilesHintLabel: NSTextField?
     private var autoRevealSavedFilesSwitch: NSSwitch!
@@ -1533,6 +1536,22 @@ class SettingsView: NSView {
         let topDivider = rowDivider()
         inner.addArrangedSubview(topDivider)
         topDivider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let askSave = makeToggleRow(
+            title: L10n.askSaveLocationLabel,
+            subtitle: L10n.askSaveLocationHint,
+            isOn: Defaults.askSaveLocation,
+            action: #selector(askSaveLocationToggled(_:))
+        )
+        askSaveLocationTitleLabel = askSave.title
+        askSaveLocationHintLabel = askSave.subtitle
+        askSaveLocationSwitch = askSave.toggle
+        inner.addArrangedSubview(askSave.row)
+        askSave.row.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let askSaveDivider = rowDivider()
+        inner.addArrangedSubview(askSaveDivider)
+        askSaveDivider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
 
         let autoReveal = makeToggleRow(
             title: L10n.autoRevealSavedFilesLabel,
@@ -2781,6 +2800,10 @@ class SettingsView: NSView {
     private func selectedScreenshotQuality(from sender: NSPopUpButton) -> ScreenshotImageQuality? {
         guard let raw = sender.selectedItem?.representedObject as? String else { return nil }
         return ScreenshotImageQuality(rawValue: raw)
+    }
+
+    @objc private func askSaveLocationToggled(_ sender: NSSwitch) {
+        Defaults.askSaveLocation = sender.state == .on
     }
 
     @objc private func autoRevealSavedFilesToggled(_ sender: NSSwitch) {
@@ -4743,6 +4766,9 @@ class SettingsView: NSView {
         refreshScreenshotQualityControls()
         savePathTitleLabel?.stringValue = L10n.savePathTitle
         savePathSubtitleLabel?.stringValue = L10n.savePathSubtitle
+        askSaveLocationTitleLabel?.stringValue = L10n.askSaveLocationLabel
+        askSaveLocationHintLabel?.stringValue = L10n.askSaveLocationHint
+        askSaveLocationSwitch?.state = Defaults.askSaveLocation ? .on : .off
         autoRevealSavedFilesTitleLabel?.stringValue = L10n.autoRevealSavedFilesLabel
         autoRevealSavedFilesHintLabel?.stringValue = L10n.autoRevealSavedFilesHint
         autoRevealSavedFilesSwitch?.state = Defaults.autoRevealSavedFiles ? .on : .off

--- a/capcap/Utilities/Defaults.swift
+++ b/capcap/Utilities/Defaults.swift
@@ -115,6 +115,8 @@ enum L10n {
     static var windowShadowSizeHint: String { s("windowShadowSizeHint") }
     static var savePathTitle: String { s("savePathTitle") }
     static var savePathSubtitle: String { s("savePathSubtitle") }
+    static var askSaveLocationLabel: String { s("askSaveLocationLabel") }
+    static var askSaveLocationHint: String { s("askSaveLocationHint") }
     static var autoRevealSavedFilesLabel: String { s("autoRevealSavedFilesLabel") }
     static var autoRevealSavedFilesHint: String { s("autoRevealSavedFilesHint") }
     static var recordingSavePathLabel: String { s("recordingSavePathLabel") }
@@ -1123,6 +1125,20 @@ struct Defaults {
         }
         set {
             defaults.set(newValue.rawValue, forKey: "recordingSavePreference")
+        }
+    }
+
+    /// When true (default), screenshot "Save to file" shows a save panel.
+    /// When false, screenshots write straight to `screenshotSaveDirectory`.
+    static var askSaveLocation: Bool {
+        get {
+            if defaults.object(forKey: "askSaveLocation") == nil {
+                return true
+            }
+            return defaults.bool(forKey: "askSaveLocation")
+        }
+        set {
+            defaults.set(newValue, forKey: "askSaveLocation")
         }
     }
 


### PR DESCRIPTION
## Summary
- 工具栏「保存到文件」默认弹出保存对话框，可选择路径与文件名
- 取消对话框时保留编辑器会话，不丢弃截图
- 设置 → 保存路径 新增「询问保存位置」开关（默认开）；关闭后恢复直接写入截图路径

## Test plan
- [ ] 默认设置下点击「保存到文件」或 ⌘S，应弹出保存对话框
- [ ] 取消对话框后仍停留在编辑器
- [ ] 确认保存后文件写入所选位置，Toast 提示正确
- [ ] 在设置中关闭「询问保存位置」后，保存应直接写入配置的截图路径
- [ ] 开启「在 Finder 中显示」时，保存成功后应选中文件