### PR TITLE
feat: 汇总截图性能、美化与保存体验改进

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Beautify";
+"beautifyPresetTransparent" = "Transparent";
 "beautifyPresetPeachBlue" = "Peach Blue";
 "beautifyPresetMintTeal" = "Mint Teal";
 "beautifyPresetPeachPink" = "Peach Pink";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Neutral Gray";
 "beautifyPresetWallpaper" = "Wallpaper";
 "beautifyShadowEffect" = "Shadow Effect";
+"beautifyAutoToggleLabel" = "Open Editor with Beautify";
+"beautifyAutoToggleHint" = "Automatically apply the last beautify preset, padding, and shadow when the editor opens";
+"beautifyDefaultPresetLabel" = "Default Preset";
+"beautifyDefaultPaddingLabel" = "Default Padding";
 "textStrokeEffect" = "Stroke";
 "textCalloutEffect" = "Callout";
 "shapeFillEffect" = "Fill";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "Save paths";
-"savePathSubtitle" = "Screenshots and recordings save here without asking for a destination";
+"savePathSubtitle" = "Default locations for screenshots and recordings";
+"askSaveLocationLabel" = "Ask for save location";
+"askSaveLocationHint" = "Show a save dialog when saving screenshots; turn off to save directly to the screenshot path";
 "autoRevealSavedFilesLabel" = "Show in Finder";
 "autoRevealSavedFilesHint" = "Select the saved screenshot or recording in Finder after a successful save";
 "recordingSavePathLabel" = "Recording save path";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Embellir";
+"beautifyPresetTransparent" = "Transparent";
 "beautifyPresetPeachBlue" = "Pêche bleu";
 "beautifyPresetMintTeal" = "Menthe sarcelle";
 "beautifyPresetPeachPink" = "Pêche rose";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Gris neutre";
 "beautifyPresetWallpaper" = "Fond d'écran";
 "beautifyShadowEffect" = "Ombre";
+"beautifyAutoToggleLabel" = "Ouvrir l'éditeur avec Beautify";
+"beautifyAutoToggleHint" = "Applique automatiquement le dernier préréglage, le padding et l'ombre à l'ouverture de l'éditeur";
+"beautifyDefaultPresetLabel" = "Préréglage par défaut";
+"beautifyDefaultPaddingLabel" = "Marge par défaut";
 "textStrokeEffect" = "Contour";
 "textCalloutEffect" = "Annotation";
 "shapeFillEffect" = "Remplir";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "Emplacements d'enregistrement";
-"savePathSubtitle" = "Les captures et enregistrements sont sauvegardés ici sans demander de destination";
+"savePathSubtitle" = "Emplacements par défaut des captures et enregistrements";
+"askSaveLocationLabel" = "Demander l'emplacement";
+"askSaveLocationHint" = "Afficher une boîte de dialogue pour les captures ; désactiver pour enregistrer directement";
 "autoRevealSavedFilesLabel" = "Afficher dans le Finder";
 "autoRevealSavedFilesHint" = "Sélectionner la capture ou l'enregistrement sauvegardé dans Finder après un enregistrement réussi";
 "recordingSavePathLabel" = "Chemin d'enregistrement";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "保存先";
-"savePathSubtitle" = "スクリーンショットと録画は保存先を確認せず、ここへ保存されます";
+"savePathSubtitle" = "スクリーンショットと録画のデフォルト保存先";
+"askSaveLocationLabel" = "保存先を確認";
+"askSaveLocationHint" = "スクリーンショット保存時にダイアログで場所を選ぶ。オフにすると保存先へ直接保存";
 "autoRevealSavedFilesLabel" = "Finder に表示";
 "autoRevealSavedFilesHint" = "保存に成功したスクリーンショットまたは録画を Finder で選択します";
 "recordingSavePathLabel" = "録画の保存先";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "装飾";
+"beautifyPresetTransparent" = "透明";
 "beautifyPresetPeachBlue" = "ピーチブルー";
 "beautifyPresetMintTeal" = "ミントティール";
 "beautifyPresetPeachPink" = "ピーチピンク";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "ニュートラルグレー";
 "beautifyPresetWallpaper" = "壁紙";
 "beautifyShadowEffect" = "影効果";
+"beautifyAutoToggleLabel" = "エディタ起動時に美化を有効化";
+"beautifyAutoToggleHint" = "エディタを開くと前回の美化プリセット・余白・影を自動適用します";
+"beautifyDefaultPresetLabel" = "デフォルトのプリセット";
+"beautifyDefaultPaddingLabel" = "デフォルトの余白";
 "textStrokeEffect" = "縁取り";
 "textCalloutEffect" = "吹き出し";
 "shapeFillEffect" = "塗りつぶし";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "저장 경로";
-"savePathSubtitle" = "스크린샷과 녹화는 저장 위치를 묻지 않고 여기에 저장됩니다";
+"savePathSubtitle" = "스크린샷과 녹화의 기본 저장 위치";
+"askSaveLocationLabel" = "저장 위치 묻기";
+"askSaveLocationHint" = "스크린샷 저장 시 대화상자로 위치를 선택합니다. 끄면 스크린샷 경로에 바로 저장";
 "autoRevealSavedFilesLabel" = "Finder에 표시";
 "autoRevealSavedFilesHint" = "저장 성공 후 Finder에서 저장된 스크린샷 또는 녹화를 선택합니다";
 "recordingSavePathLabel" = "녹화 저장 경로";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "꾸미기";
+"beautifyPresetTransparent" = "투명";
 "beautifyPresetPeachBlue" = "피치 블루";
 "beautifyPresetMintTeal" = "민트 틸";
 "beautifyPresetPeachPink" = "피치 핑크";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "뉴트럴 그레이";
 "beautifyPresetWallpaper" = "배경화면";
 "beautifyShadowEffect" = "그림자";
+"beautifyAutoToggleLabel" = "편집기 열 때 미화 자동 적용";
+"beautifyAutoToggleHint" = "편집기를 열면 마지막 미화 프리셋, 여백, 그림자를 자동으로 적용합니다";
+"beautifyDefaultPresetLabel" = "기본 프리셋";
+"beautifyDefaultPaddingLabel" = "기본 여백";
 "textStrokeEffect" = "테두리";
 "textCalloutEffect" = "콜아웃";
 "shapeFillEffect" = "채우기";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Оформление";
+"beautifyPresetTransparent" = "Прозрачный";
 "beautifyPresetPeachBlue" = "Персиково-синий";
 "beautifyPresetMintTeal" = "Мятно-бирюзовый";
 "beautifyPresetPeachPink" = "Персиково-розовый";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Нейтральный серый";
 "beautifyPresetWallpaper" = "Обои";
 "beautifyShadowEffect" = "Тень";
+"beautifyAutoToggleLabel" = "Открывать редактор с Beautify";
+"beautifyAutoToggleHint" = "Автоматически применять последний пресет, отступ и тень при открытии редактора";
+"beautifyDefaultPresetLabel" = "Пресет по умолчанию";
+"beautifyDefaultPaddingLabel" = "Отступ по умолчанию";
 "textStrokeEffect" = "Обводка";
 "textCalloutEffect" = "Выноска";
 "shapeFillEffect" = "Заливка";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "Пути сохранения";
-"savePathSubtitle" = "Снимки и записи сохраняются сюда без запроса папки назначения";
+"savePathSubtitle" = "Пути по умолчанию для снимков и записей";
+"askSaveLocationLabel" = "Спрашивать путь сохранения";
+"askSaveLocationHint" = "Показывать диалог при сохранении снимка; выключите, чтобы сохранять сразу в путь снимков";
 "autoRevealSavedFilesLabel" = "Показать в Finder";
 "autoRevealSavedFilesHint" = "Выбирать сохранённый снимок или запись в Finder после успешного сохранения";
 "recordingSavePathLabel" = "Путь для записей";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "Đường dẫn lưu";
-"savePathSubtitle" = "Ảnh chụp và bản ghi được lưu tại đây mà không hỏi vị trí đích";
+"savePathSubtitle" = "Vị trí lưu mặc định cho ảnh chụp và bản ghi";
+"askSaveLocationLabel" = "Hỏi vị trí lưu";
+"askSaveLocationHint" = "Hiện hộp thoại khi lưu ảnh chụp; tắt để lưu thẳng vào đường dẫn ảnh chụp";
 "autoRevealSavedFilesLabel" = "Hiển thị trong Finder";
 "autoRevealSavedFilesHint" = "Chọn ảnh chụp hoặc bản ghi đã lưu trong Finder sau khi lưu thành công";
 "recordingSavePathLabel" = "Đường dẫn lưu bản ghi";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "Làm đẹp";
+"beautifyPresetTransparent" = "Trong suốt";
 "beautifyPresetPeachBlue" = "Hồng đào xanh";
 "beautifyPresetMintTeal" = "Bạc hà lam ngọc";
 "beautifyPresetPeachPink" = "Hồng đào";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "Xám trung tính";
 "beautifyPresetWallpaper" = "Hình nền";
 "beautifyShadowEffect" = "Hiệu ứng bóng";
+"beautifyAutoToggleLabel" = "Mở trình chỉnh sửa với Beautify";
+"beautifyAutoToggleHint" = "Tự động áp dụng preset, lề và bóng đã dùng lần trước khi mở trình chỉnh sửa";
+"beautifyDefaultPresetLabel" = "Preset mặc định";
+"beautifyDefaultPaddingLabel" = "Lề mặc định";
 "textStrokeEffect" = "Viền chữ";
 "textCalloutEffect" = "Chú thích";
 "shapeFillEffect" = "Tô màu";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "保存路径";
-"savePathSubtitle" = "截图和录制会直接保存到这些路径，不再询问保存位置";
+"savePathSubtitle" = "配置截图和录制的默认保存位置";
+"askSaveLocationLabel" = "询问保存位置";
+"askSaveLocationHint" = "保存截图时弹出对话框选择位置，关闭后直接保存到截图路径";
 "autoRevealSavedFilesLabel" = "在 Finder 中显示";
 "autoRevealSavedFilesHint" = "保存成功后，在 Finder 中选中刚保存的截图或录制";
 "recordingSavePathLabel" = "录制保存路径";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "美化";
+"beautifyPresetTransparent" = "透明";
 "beautifyPresetPeachBlue" = "粉蓝";
 "beautifyPresetMintTeal" = "薄荷青";
 "beautifyPresetPeachPink" = "桃粉";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "中性灰";
 "beautifyPresetWallpaper" = "壁纸";
 "beautifyShadowEffect" = "阴影效果";
+"beautifyAutoToggleLabel" = "进入编辑器默认开启美化";
+"beautifyAutoToggleHint" = "打开编辑器时自动应用上次的美化预设、边距和阴影";
+"beautifyDefaultPresetLabel" = "默认预设";
+"beautifyDefaultPaddingLabel" = "默认边距";
 "textStrokeEffect" = "描边";
 "textCalloutEffect" = "标注";
 "shapeFillEffect" = "填充";

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 
 /* Beautify */
 "beautify" = "美化";
+"beautifyPresetTransparent" = "透明";
 "beautifyPresetPeachBlue" = "蜜桃藍";
 "beautifyPresetMintTeal" = "薄荷青";
 "beautifyPresetPeachPink" = "蜜桃粉";
@@ -247,6 +248,10 @@
 "beautifyPresetNeutralGray" = "中性灰";
 "beautifyPresetWallpaper" = "桌布";
 "beautifyShadowEffect" = "陰影效果";
+"beautifyAutoToggleLabel" = "進入編輯器預設開啟美化";
+"beautifyAutoToggleHint" = "開啟編輯器時自動套用上次的美化預設、邊距與陰影";
+"beautifyDefaultPresetLabel" = "預設樣式";
+"beautifyDefaultPaddingLabel" = "預設邊距";
 "textStrokeEffect" = "描邊";
 "textCalloutEffect" = "標註";
 "shapeFillEffect" = "填充";

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -553,7 +553,9 @@
 
 /* Save paths */
 "savePathTitle" = "儲存路徑";
-"savePathSubtitle" = "截圖和錄製會直接儲存到這些路徑，不再詢問儲存位置";
+"savePathSubtitle" = "設定截圖和錄製的預設儲存位置";
+"askSaveLocationLabel" = "詢問儲存位置";
+"askSaveLocationHint" = "儲存截圖時彈出對話框選擇位置，關閉後直接儲存到截圖路徑";
 "autoRevealSavedFilesLabel" = "在 Finder 中顯示";
 "autoRevealSavedFilesHint" = "儲存成功後，在 Finder 中選取剛儲存的截圖或錄製";
 "recordingSavePathLabel" = "錄製儲存路徑";

--- a/Tests/capcapTests/OverlayPresentationTests.swift
+++ b/Tests/capcapTests/OverlayPresentationTests.swift
@@ -1,0 +1,350 @@
+import AppKit
+import XCTest
+@testable import capcap
+
+@MainActor
+final class OverlayPresentationTests: XCTestCase {
+    override func tearDown() {
+        ToastWindow.dismiss()
+        super.tearDown()
+    }
+
+    func testOverlayIsInteractiveBeforeTwoSecondPreparationFinishes() {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider(delay: 2)
+        var controller: OverlayWindowController!
+        var captureStartedBeforePresentation = false
+        provider.onCapture = {
+            captureStartedBeforePresentation = controller.activeSelectionViews.isEmpty
+        }
+        controller = OverlayWindowController(
+            snapshotProvider: provider,
+            windowSnapshotLoader: { _ in
+                Thread.sleep(forTimeInterval: 2)
+                return .success([])
+            },
+            onComplete: { _ in }
+        )
+
+        let started = ProcessInfo.processInfo.systemUptime
+        controller.activate()
+        let elapsed = ProcessInfo.processInfo.systemUptime - started
+
+        XCTAssertTrue(controller.isOverlayPresented)
+        XCTAssertTrue(controller.isSelectionInteractive)
+        XCTAssertLessThan(elapsed, 0.1)
+        XCTAssertEqual(provider.captureCount, 1)
+        XCTAssertTrue(captureStartedBeforePresentation)
+        XCTAssertTrue(controller.activeSelectionViews.allSatisfy {
+            $0.window?.isKeyWindow == false
+        })
+
+        controller.activate()
+        XCTAssertEqual(provider.captureCount, 1, "Repeated activation must not start a second session")
+        controller.cancel()
+        XCTAssertEqual(provider.cancellationCount, 1)
+    }
+
+    func testSelectionWaitsWithoutBlockingAndResumesWhenItsSnapshotArrives() throws {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider()
+        let controller = OverlayWindowController(snapshotProvider: provider, onComplete: { _ in })
+        controller.activate()
+
+        let selectionView = try XCTUnwrap(controller.activeSelectionViews.first)
+        let displayID = try XCTUnwrap(provider.targets.first?.displayID)
+        controller.selectionDidComplete(
+            rect: selectionRect(in: selectionView),
+            inView: selectionView,
+            isWindowSelection: false,
+            windowID: nil
+        )
+
+        XCTAssertTrue(controller.isWaitingForSnapshot)
+        XCTAssertFalse(controller.hasActiveEditor)
+
+        provider.emit(.image(displayID: displayID, image: makeImage()))
+        drainMainRunLoop()
+
+        XCTAssertFalse(controller.isWaitingForSnapshot)
+        XCTAssertTrue(controller.hasActiveEditor)
+        XCTAssertEqual(controller.appliedSnapshotCount, 1)
+        controller.cancel()
+    }
+
+    func testSelectedDisplayFailureEndsSessionWithoutSynchronousFallback() throws {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider()
+        var completionCount = 0
+        let controller = OverlayWindowController(snapshotProvider: provider) { _ in
+            completionCount += 1
+        }
+        controller.activate()
+
+        let selectionView = try XCTUnwrap(controller.activeSelectionViews.first)
+        let displayID = try XCTUnwrap(provider.targets.first?.displayID)
+        controller.selectionDidComplete(
+            rect: selectionRect(in: selectionView),
+            inView: selectionView,
+            isWindowSelection: false,
+            windowID: nil
+        )
+        provider.emit(.failure(displayID: displayID, error: TestCaptureError.failed))
+        drainMainRunLoop()
+
+        XCTAssertTrue(controller.isCaptureSessionEnded)
+        XCTAssertFalse(controller.isOverlayPresented)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertEqual(provider.cancellationCount, 1)
+    }
+
+    func testFinishedWithoutSelectedDisplaySnapshotFailsExplicitly() throws {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider()
+        var completionCount = 0
+        let controller = OverlayWindowController(snapshotProvider: provider) { _ in
+            completionCount += 1
+        }
+        controller.activate()
+        provider.emit(.finished)
+        drainMainRunLoop()
+
+        let selectionView = try XCTUnwrap(controller.activeSelectionViews.first)
+        controller.selectionDidComplete(
+            rect: selectionRect(in: selectionView),
+            inView: selectionView,
+            isWindowSelection: false,
+            windowID: nil
+        )
+
+        XCTAssertTrue(controller.isCaptureSessionEnded)
+        XCTAssertEqual(completionCount, 1)
+    }
+
+    func testCancelDiscardsLateSnapshotCallback() throws {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider()
+        var completionCount = 0
+        let controller = OverlayWindowController(snapshotProvider: provider) { _ in
+            completionCount += 1
+        }
+        controller.activate()
+        let displayID = try XCTUnwrap(provider.targets.first?.displayID)
+
+        controller.cancel()
+        provider.emit(.image(displayID: displayID, image: makeImage()))
+        drainMainRunLoop()
+
+        XCTAssertEqual(controller.appliedSnapshotCount, 0)
+        XCTAssertEqual(provider.cancellationCount, 1)
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertTrue(controller.isCaptureSessionEnded)
+    }
+
+    func testEscapeCancelsWhileSnapshotIsPending() throws {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider(delay: 2)
+        var completionCount = 0
+        let controller = OverlayWindowController(snapshotProvider: provider) { _ in
+            completionCount += 1
+        }
+        controller.activate()
+        let windowNumber = try XCTUnwrap(controller.activeSelectionViews.first?.window?.windowNumber)
+        let escape = try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: windowNumber,
+                context: nil,
+                characters: "\u{1B}",
+                charactersIgnoringModifiers: "\u{1B}",
+                isARepeat: false,
+                keyCode: 53
+            )
+        )
+
+        NSApp.sendEvent(escape)
+        drainMainRunLoop()
+
+        XCTAssertTrue(controller.isCaptureSessionEnded)
+        XCTAssertEqual(provider.cancellationCount, 1)
+        XCTAssertEqual(completionCount, 1)
+    }
+
+    func testOverlayPanelsAreReusedAcrossSessions() throws {
+        _ = NSApplication.shared
+        let firstController = OverlayWindowController(
+            snapshotProvider: ControlledScreenSnapshotProvider(),
+            onComplete: { _ in }
+        )
+        firstController.activate()
+        let firstPanels = firstController.activeSelectionViews.compactMap(\.window)
+        XCTAssertFalse(firstPanels.isEmpty)
+        firstController.cancel()
+
+        let secondController = OverlayWindowController(
+            snapshotProvider: ControlledScreenSnapshotProvider(),
+            onComplete: { _ in }
+        )
+        secondController.activate()
+        let secondPanels = secondController.activeSelectionViews.compactMap(\.window)
+
+        XCTAssertEqual(firstPanels.count, secondPanels.count)
+        XCTAssertTrue(zip(firstPanels, secondPanels).allSatisfy { $0 === $1 })
+        secondController.cancel()
+    }
+
+    func testScreenParameterChangeCancelsSelectionSession() {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider(delay: 2)
+        var completionCount = 0
+        let controller = OverlayWindowController(snapshotProvider: provider) { _ in
+            completionCount += 1
+        }
+        controller.activate()
+
+        controller.screenParametersDidChange()
+
+        XCTAssertTrue(controller.isCaptureSessionEnded)
+        XCTAssertEqual(provider.cancellationCount, 1)
+        XCTAssertEqual(completionCount, 1)
+    }
+
+    func testCancelClearsPendingWindowCaptureContinuation() throws {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider()
+        let controller = OverlayWindowController(
+            snapshotProvider: provider,
+            windowSnapshotLoader: { _ in .success([]) },
+            windowImageLoader: { _, _ in
+                try await Task.sleep(for: .seconds(2))
+                return nil
+            },
+            onComplete: { _ in }
+        )
+        controller.activate()
+        let selectionView = try XCTUnwrap(controller.activeSelectionViews.first)
+        let displayID = try XCTUnwrap(provider.targets.first?.displayID)
+        provider.emit(.image(displayID: displayID, image: makeImage()))
+        drainMainRunLoop()
+
+        controller.selectionDidComplete(
+            rect: selectionRect(in: selectionView),
+            inView: selectionView,
+            isWindowSelection: true,
+            windowID: 42
+        )
+        XCTAssertTrue(controller.isWaitingForWindowCapture)
+
+        controller.cancel()
+        drainMainRunLoop()
+
+        XCTAssertFalse(controller.isWaitingForWindowCapture)
+        XCTAssertTrue(controller.isCaptureSessionEnded)
+    }
+
+    func testSurfaceIsWarmOnlyAfterPresentedFrame() throws {
+        _ = NSApplication.shared
+        let screen = try XCTUnwrap(NSScreen.screens.first)
+        let panel = OverlayPanel(
+            contentRect: screen.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        let stalePresentationToken = panel.prepareSurface(for: screen)
+
+        XCTAssertFalse(panel.hasPresentedSurface(for: screen))
+        XCTAssertTrue(panel.markSurfacePresented(
+            for: screen,
+            presentationToken: stalePresentationToken
+        ))
+        XCTAssertTrue(panel.hasPresentedSurface(for: screen))
+        panel.invalidatePresentedSurface()
+        XCTAssertFalse(panel.hasPresentedSurface(for: screen))
+        XCTAssertFalse(panel.markSurfacePresented(
+            for: screen,
+            presentationToken: stalePresentationToken
+        ))
+        XCTAssertFalse(panel.hasPresentedSurface(for: screen))
+        panel.close()
+    }
+
+    private func selectionRect(in view: SelectionView) -> NSRect {
+        NSRect(
+            x: 10,
+            y: 10,
+            width: min(100, max(5, view.bounds.width - 20)),
+            height: min(80, max(5, view.bounds.height - 20))
+        )
+    }
+
+    private func makeImage() -> CGImage {
+        let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return context.makeImage()!
+    }
+
+    private func drainMainRunLoop() {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+
+}
+
+private final class ControlledScreenSnapshotProvider: ScreenSnapshotProviding {
+    private(set) var captureCount = 0
+    private(set) var cancellationCount = 0
+    private(set) var targets: [ScreenSnapshotTarget] = []
+    private var eventHandler: ((ScreenSnapshotEvent) -> Void)?
+    private var delayedWorkItem: DispatchWorkItem?
+    private let delay: TimeInterval?
+    var onCapture: (() -> Void)?
+
+    init(delay: TimeInterval? = nil) {
+        self.delay = delay
+    }
+
+    func prewarm() {}
+
+    @discardableResult
+    func capture(
+        targets: [ScreenSnapshotTarget],
+        eventHandler: @escaping (ScreenSnapshotEvent) -> Void
+    ) -> ScreenSnapshotCancellation {
+        captureCount += 1
+        self.targets = targets
+        self.eventHandler = eventHandler
+        onCapture?()
+
+        if let delay {
+            let workItem = DispatchWorkItem { eventHandler(.finished) }
+            delayedWorkItem = workItem
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                deadline: .now() + delay,
+                execute: workItem
+            )
+        }
+
+        return { [weak self] in
+            self?.cancellationCount += 1
+            self?.delayedWorkItem?.cancel()
+        }
+    }
+
+    func emit(_ event: ScreenSnapshotEvent) {
+        eventHandler?(event)
+    }
+}
+
+private enum TestCaptureError: Error {
+    case failed
+}

--- a/capcap/App/AppDelegate.swift
+++ b/capcap/App/AppDelegate.swift
@@ -49,6 +49,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         clipboardTextHistoryMonitor.stop()
     }
 
+    func applicationDidChangeScreenParameters(_ notification: Notification) {
+        guard appInitialized else { return }
+        overlayController?.screenParametersDidChange()
+        let displayIDs = Set(NSScreen.screens.compactMap { screen in
+            screen.deviceDescription[
+                NSDeviceDescriptionKey("NSScreenNumber")
+            ] as? CGDirectDisplayID
+        })
+        ScreenSnapshotProvider.shared.invalidateAndPrewarm(displayIDs: displayIDs)
+        OverlayWindowController.invalidateAndPrewarmPresentationSurfaces()
+    }
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if appInitialized {
             scheduleSettingsOpenFromReopen()
@@ -104,6 +116,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         appInitialized = true
 
         ImageEditLauncher.clearTempDir()
+        OverlayWindowController.prewarmPresentationSurfaces()
+        if AppPermissions.screenRecordingGranted {
+            ScreenSnapshotProvider.shared.prewarm()
+        }
         ImageMergeLauncher.shared.onContinueEditing = { [weak self] image in
             self?.continueEditingMergedImage(image)
         }
@@ -112,7 +128,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         statusBarController = StatusBarController(
-            onTakeScreenshot: { [weak self] in self?.handleTrigger() },
+            onTakeScreenshot: { [weak self] in
+                self?.handleTrigger(
+                    triggerContext: CaptureTriggerContext(source: .menu)
+                )
+            },
             onTakeFullScreenScreenshot: { [weak self] in self?.handleFullScreenScreenshotTrigger() },
             onRecord: { [weak self] in self?.handleRecordingTrigger() },
             onMergeImages: { [weak self] in self?.handleImageMergeMenuTrigger() },
@@ -123,7 +143,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         statusBarController.setMenuBarVisible(Defaults.showMenuBar)
 
         keyMonitor = KeyMonitor(
-            onTrigger: { [weak self] in self?.handleDoubleTapCommand() },
+            onTrigger: { [weak self] context in
+                guard let self else {
+                    context.finish(.ignored)
+                    return
+                }
+                self.handleDoubleTapCommand(triggerContext: context)
+            },
             onCountdownTrigger: { [weak self] in self?.handleCountdownTrigger() }
         )
 
@@ -151,8 +177,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             keyMonitor?.isEnabled = true
             keyMonitor?.isRegularDoubleTapEnabled = !Defaults.hasCustomScreenshotHotkey
             if Defaults.hasCustomScreenshotHotkey {
-                HotkeyManager.shared.register { [weak self] in
-                    self?.stopRecordingAndSave()
+                HotkeyManager.shared.register { [weak self] context in
+                    guard let self else {
+                        context.finish(.ignored)
+                        return
+                    }
+                    self.stopRecordingAndSave()
+                    context.finish(.rerouted)
                 }
             } else {
                 HotkeyManager.shared.unregister()
@@ -163,8 +194,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         keyMonitor?.isEnabled = true
         if Defaults.hasCustomScreenshotHotkey {
-            HotkeyManager.shared.register { [weak self] in
-                self?.handleTrigger(fromShortcut: true)
+            HotkeyManager.shared.register { [weak self] context in
+                guard let self else {
+                    context.finish(.ignored)
+                    return
+                }
+                self.handleTrigger(fromShortcut: true, triggerContext: context)
             }
             HotkeyManager.shared.registerCountdown { [weak self] in
                 self?.handleCountdownTrigger()
@@ -383,33 +418,50 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// KeyMonitor entry point for plain double-tap ⌘. While an overlay is
     /// active this is the default copy-to-clipboard hotkey; otherwise it falls
     /// through to the regular screenshot trigger.
-    private func handleDoubleTapCommand() {
+    private func handleDoubleTapCommand(triggerContext: CaptureTriggerContext) {
         if recordingEngine != nil {
             stopRecordingAndSave()
+            triggerContext.finish(.rerouted)
             return
         }
         if let overlay = overlayController {
             if !Defaults.hasCustomClipboardHotkey {
                 overlay.confirmFromKeyboard()
             }
+            triggerContext.finish(.rerouted)
             return
         }
-        handleTrigger(fromShortcut: true)
+        handleTrigger(fromShortcut: true, triggerContext: triggerContext)
     }
 
-    func handleTrigger(fromShortcut: Bool = false) {
+    func handleTrigger(
+        fromShortcut: Bool = false,
+        triggerContext: CaptureTriggerContext? = nil
+    ) {
+        let context = triggerContext ?? CaptureTriggerContext(
+            source: fromShortcut ? .keyboardShortcut : .programmatic
+        )
+        context.mark(.handleTrigger)
+
         if recordingEngine != nil {
             stopRecordingAndSave()
+            context.finish(.rerouted)
             return
         }
-        guard overlayController == nil, recordingEngine == nil else { return }
+        guard overlayController == nil, recordingEngine == nil else {
+            context.finish(.ignored)
+            return
+        }
         if resumeSuspendedEditIfAvailable() {
+            context.finish(.rerouted)
             return
         }
-        if fromShortcut {
-            UpdateChecker.shared.checkFromScreenshotShortcutIfDue()
-        }
-        startCapture()
+        startCapture(
+            triggerContext: context,
+            onFirstFramePresented: fromShortcut ? {
+                UpdateChecker.shared.checkFromScreenshotShortcutIfDue()
+            } : nil
+        )
     }
 
     func handleRecordingTrigger() {
@@ -490,7 +542,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             seconds: Defaults.countdownSeconds,
             onFinish: { [weak self] in
                 self?.countdownActive = false
-                self?.startCapture()
+                self?.startCapture(
+                    triggerContext: CaptureTriggerContext(source: .countdown)
+                )
             },
             onCancel: { [weak self] in
                 self?.countdownActive = false
@@ -640,11 +694,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         applyHotkeyState()
     }
 
-    func startCapture(postCaptureAction: OverlayWindowController.PostCaptureAction = .edit) {
-        guard overlayController == nil, recordingEngine == nil else { return }
+    func startCapture(
+        postCaptureAction: OverlayWindowController.PostCaptureAction = .edit,
+        triggerContext: CaptureTriggerContext? = nil,
+        onFirstFramePresented: (() -> Void)? = nil
+    ) {
+        let context = triggerContext ?? CaptureTriggerContext(source: .programmatic)
+        context.mark(.startCapture)
+        guard overlayController == nil, recordingEngine == nil else {
+            context.finish(.ignored)
+            return
+        }
         let focusRestorer = SourceAppFocusRestorer.captureFrontmostApplication()
         overlayController = OverlayWindowController(
             postCaptureAction: postCaptureAction,
+            triggerContext: context,
+            onFirstFramePresented: onFirstFramePresented,
             onRecordingSelection: { [weak self] rect, screen in
                 self?.beginRecording(rect: rect, screen: screen)
             },

--- a/capcap/Capture/OverlayPanelPool.swift
+++ b/capcap/Capture/OverlayPanelPool.swift
@@ -1,0 +1,373 @@
+import AppKit
+import QuartzCore
+
+/// Retains one already-committed full-screen surface per display so a capture
+/// trigger never has to wait for WindowServer to allocate a cold surface.
+final class OverlayPanelPool {
+    private struct PanelLease {
+        let displayID: CGDirectDisplayID
+        let panel: OverlayPanel
+    }
+
+    static let shared = OverlayPanelPool()
+
+    private var panelsByDisplayID: [CGDirectDisplayID: OverlayPanel] = [:]
+    private var warmingPanelsByDisplayID: [CGDirectDisplayID: OverlayPanel] = [:]
+    private var warmupTimeoutsByDisplayID: [CGDirectDisplayID: DispatchWorkItem] = [:]
+    private var leasedPanels: [ObjectIdentifier: PanelLease] = [:]
+    private var leaseCountsByDisplayID: [CGDirectDisplayID: Int] = [:]
+
+    func prewarm(screens: [NSScreen]) {
+        assertMainThread()
+        reconcilePanels(with: screens)
+
+        for screen in screens {
+            guard let displayID = Self.displayID(for: screen),
+                  leaseCountsByDisplayID[displayID, default: 0] == 0 else { continue }
+            if let warmingPanel = warmingPanelsByDisplayID[displayID] {
+                guard !warmingPanel.isConfigured(for: screen),
+                      let panel = takeWarmingPanel(displayID: displayID) else { continue }
+                startWarmup(panel: panel, screen: screen, displayID: displayID)
+                continue
+            }
+            if let pooledPanel = panelsByDisplayID[displayID] {
+                guard !pooledPanel.hasPresentedSurface(for: screen),
+                      let panel = panelsByDisplayID.removeValue(forKey: displayID) else { continue }
+                startWarmup(panel: panel, screen: screen, displayID: displayID)
+                continue
+            }
+            startWarmup(panel: makePanel(for: screen), screen: screen, displayID: displayID)
+        }
+    }
+
+    func invalidateAndPrewarm(screens: [NSScreen]) {
+        assertMainThread()
+        panelsByDisplayID.values.forEach { $0.invalidatePresentedSurface() }
+        leasedPanels.values.forEach { $0.panel.invalidatePresentedSurface() }
+
+        let warmingDisplayIDs = Array(warmingPanelsByDisplayID.keys)
+        for displayID in warmingDisplayIDs {
+            guard let panel = takeWarmingPanel(displayID: displayID) else { continue }
+            panel.invalidatePresentedSurface()
+            resetForStorage(panel)
+            storePooled(panel, displayID: displayID)
+        }
+        prewarm(screens: screens)
+    }
+
+    func lease(for screen: NSScreen) -> OverlayPanel {
+        assertMainThread()
+        let displayID = Self.displayID(for: screen)
+        let panel = displayID.flatMap(takeWarmingPanel(displayID:))
+            ?? displayID.flatMap { panelsByDisplayID.removeValue(forKey: $0) }
+            ?? makePanel(for: screen)
+
+        panel.prepareSurface(for: screen)
+        if let displayID {
+            leasedPanels[ObjectIdentifier(panel)] = PanelLease(
+                displayID: displayID,
+                panel: panel
+            )
+            leaseCountsByDisplayID[displayID, default: 0] += 1
+        }
+        return panel
+    }
+
+    func markSurfacePresented(
+        _ window: NSWindow,
+        for screen: NSScreen,
+        presentationToken: UInt64
+    ) -> Bool {
+        assertMainThread()
+        guard let panel = window as? OverlayPanel else { return false }
+        return panel.markSurfacePresented(
+            for: screen,
+            presentationToken: presentationToken
+        )
+    }
+
+    func recycle(_ window: NSWindow) {
+        assertMainThread()
+        guard let panel = window as? OverlayPanel else {
+            window.orderOut(nil)
+            return
+        }
+        let identifier = ObjectIdentifier(panel)
+        guard let lease = leasedPanels.removeValue(forKey: identifier) else {
+            dispose(panel)
+            return
+        }
+        let displayID = lease.displayID
+        decrementLeaseCount(for: displayID)
+        resetForStorage(panel)
+
+        guard let screen = NSScreen.screens.first(where: {
+            Self.displayID(for: $0) == displayID
+        }) else {
+            dispose(panel)
+            return
+        }
+        guard panel.hasPresentedSurface(for: screen) else {
+            startWarmup(panel: panel, screen: screen, displayID: displayID)
+            return
+        }
+
+        if let warmingPanel = takeWarmingPanel(displayID: displayID) {
+            dispose(warmingPanel)
+        }
+        storePooled(panel, displayID: displayID)
+    }
+
+    private func reconcilePanels(with screens: [NSScreen]) {
+        let liveDisplayIDs = Set(screens.compactMap(Self.displayID(for:)))
+        let stalePooledIDs = panelsByDisplayID.keys.filter {
+            !liveDisplayIDs.contains($0)
+        }
+        for displayID in stalePooledIDs {
+            if let panel = panelsByDisplayID.removeValue(forKey: displayID) {
+                dispose(panel)
+            }
+        }
+        let staleWarmingIDs = warmingPanelsByDisplayID.keys.filter {
+            !liveDisplayIDs.contains($0)
+        }
+        for displayID in staleWarmingIDs {
+            if let panel = takeWarmingPanel(displayID: displayID) {
+                dispose(panel)
+            }
+        }
+        let staleTimeoutIDs = warmupTimeoutsByDisplayID.keys.filter {
+            !liveDisplayIDs.contains($0)
+        }
+        for displayID in staleTimeoutIDs {
+            warmupTimeoutsByDisplayID.removeValue(forKey: displayID)?.cancel()
+        }
+    }
+
+    private func makePanel(for screen: NSScreen) -> OverlayPanel {
+        let panel = OverlayPanel(
+            contentRect: screen.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isReleasedWhenClosed = false
+        panel.isExcludedFromWindowsMenu = true
+        return panel
+    }
+
+    private func startWarmup(
+        panel: OverlayPanel,
+        screen: NSScreen,
+        displayID: CGDirectDisplayID
+    ) {
+        if warmingPanelsByDisplayID[displayID] !== panel,
+           let replacedPanel = takeWarmingPanel(displayID: displayID) {
+            dispose(replacedPanel)
+        }
+        let presentationToken = panel.prepareSurface(for: screen)
+        panel.level = .screenSaver
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.sharingType = .none
+        panel.acceptsMouseMovedEvents = false
+        panel.animationBehavior = .none
+
+        let warmupView = OverlayWarmupView(
+            frame: NSRect(origin: .zero, size: screen.frame.size)
+        )
+        warmupView.onFirstFramePresented = { [weak self, weak panel] in
+            guard let self, let panel else { return }
+            guard panel.markSurfacePresented(
+                for: screen,
+                presentationToken: presentationToken
+            ) else { return }
+            self.finishWarmup(
+                panel: panel,
+                displayID: displayID,
+                timedOut: false
+            )
+        }
+        panel.contentView = warmupView
+        warmingPanelsByDisplayID[displayID] = panel
+        panel.orderFrontRegardless()
+
+        let timeout = DispatchWorkItem { [weak self, weak panel] in
+            guard let panel else { return }
+            self?.finishWarmup(
+                panel: panel,
+                displayID: displayID,
+                timedOut: true
+            )
+        }
+        warmupTimeoutsByDisplayID[displayID] = timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: timeout)
+    }
+
+    private func takeWarmingPanel(displayID: CGDirectDisplayID) -> OverlayPanel? {
+        guard let panel = warmingPanelsByDisplayID.removeValue(forKey: displayID) else {
+            return nil
+        }
+        warmupTimeoutsByDisplayID.removeValue(forKey: displayID)?.cancel()
+        (panel.contentView as? OverlayWarmupView)?.cancelPresentationTracking()
+        panel.contentView = nil
+        return panel
+    }
+
+    private func finishWarmup(
+        panel: OverlayPanel,
+        displayID: CGDirectDisplayID,
+        timedOut: Bool
+    ) {
+        guard warmingPanelsByDisplayID[displayID] === panel else { return }
+        _ = takeWarmingPanel(displayID: displayID)
+        resetForStorage(panel)
+        storePooled(panel, displayID: displayID)
+
+        guard timedOut else { return }
+        DispatchQueue.global(qos: .utility).async {
+            DiagnosticLog.log(
+                "overlay-prewarm",
+                "presentation-surface-timeout",
+                metadata: ["displayID": displayID]
+            )
+        }
+    }
+
+    private func storePooled(_ panel: OverlayPanel, displayID: CGDirectDisplayID) {
+        if let replacedPanel = panelsByDisplayID.updateValue(panel, forKey: displayID),
+           replacedPanel !== panel {
+            dispose(replacedPanel)
+        }
+    }
+
+    private func resetForStorage(_ panel: OverlayPanel) {
+        _ = panel.makeFirstResponder(nil)
+        panel.orderOut(nil)
+        panel.contentView = nil
+        panel.initialFirstResponder = nil
+        panel.ignoresMouseEvents = true
+        panel.acceptsMouseMovedEvents = false
+        panel.collectionBehavior = []
+        panel.sharingType = .none
+    }
+
+    private func dispose(_ panel: OverlayPanel) {
+        (panel.contentView as? OverlayWarmupView)?.cancelPresentationTracking()
+        resetForStorage(panel)
+        panel.close()
+    }
+
+    private func decrementLeaseCount(for displayID: CGDirectDisplayID) {
+        let remaining = leaseCountsByDisplayID[displayID, default: 1] - 1
+        if remaining > 0 {
+            leaseCountsByDisplayID[displayID] = remaining
+        } else {
+            leaseCountsByDisplayID.removeValue(forKey: displayID)
+        }
+    }
+
+    private func assertMainThread() {
+        precondition(Thread.isMainThread, "Overlay panel lifecycle must stay on the main thread")
+    }
+
+    private static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+        screen.deviceDescription[
+            NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? CGDirectDisplayID
+    }
+}
+
+private final class OverlayWarmupView: NSView {
+    var onFirstFramePresented: (() -> Void)?
+
+    private var displayLink: CADisplayLink?
+    private var didSchedulePresentation = false
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.black.withAlphaComponent(0.001).setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        schedulePresentationIfNeeded()
+    }
+
+    func cancelPresentationTracking() {
+        displayLink?.invalidate()
+        displayLink = nil
+        onFirstFramePresented = nil
+    }
+
+    private func schedulePresentationIfNeeded() {
+        guard !didSchedulePresentation else { return }
+        didSchedulePresentation = true
+        let displayLink = displayLink(
+            target: self,
+            selector: #selector(displayLinkDidFire(_:))
+        )
+        self.displayLink = displayLink
+        displayLink.add(to: .main, forMode: .common)
+    }
+
+    @objc private func displayLinkDidFire(_ displayLink: CADisplayLink) {
+        displayLink.invalidate()
+        self.displayLink = nil
+        onFirstFramePresented?()
+        onFirstFramePresented = nil
+    }
+}
+
+/// The selection shell stays nonactivating; editor code may explicitly make
+/// it key only after the frozen screenshot is ready.
+final class OverlayPanel: NSPanel {
+    private struct SurfaceSignature: Equatable {
+        let frame: NSRect
+        let scale: CGFloat
+    }
+
+    private var configuredSurface: SurfaceSignature?
+    private var presentedSurface: SurfaceSignature?
+    private(set) var surfacePresentationToken: UInt64 = 0
+
+    @discardableResult
+    func prepareSurface(for screen: NSScreen) -> UInt64 {
+        let signature = Self.signature(for: screen)
+        if configuredSurface != signature {
+            presentedSurface = nil
+        }
+        surfacePresentationToken &+= 1
+        setFrame(screen.frame, display: false)
+        configuredSurface = signature
+        return surfacePresentationToken
+    }
+
+    func isConfigured(for screen: NSScreen) -> Bool {
+        configuredSurface == Self.signature(for: screen)
+    }
+
+    @discardableResult
+    func markSurfacePresented(
+        for screen: NSScreen,
+        presentationToken: UInt64
+    ) -> Bool {
+        guard presentationToken == surfacePresentationToken,
+              isConfigured(for: screen) else { return false }
+        presentedSurface = Self.signature(for: screen)
+        return true
+    }
+
+    func hasPresentedSurface(for screen: NSScreen) -> Bool {
+        presentedSurface == Self.signature(for: screen)
+    }
+
+    func invalidatePresentedSurface() {
+        surfacePresentationToken &+= 1
+        presentedSurface = nil
+    }
+
+    private static func signature(for screen: NSScreen) -> SurfaceSignature {
+        SurfaceSignature(frame: screen.frame, scale: screen.backingScaleFactor)
+    }
+
+    override var canBecomeKey: Bool { true }
+}

--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -1,6 +1,9 @@
 import AppKit
 import QuartzCore
 
+typealias WindowSnapshotLoader = @Sendable (CGFloat) -> Result<[DetectedWindow], WindowDetectionError>
+typealias WindowImageLoader = @Sendable (CGWindowID, NSSize) async throws -> NSImage?
+
 struct CaptureResult {
     let rect: CGRect       // In CG coordinates (top-left origin) for capture
     let screen: NSScreen   // The screen where selection was made
@@ -63,8 +66,6 @@ class OverlayWindowController {
     private var escGlobalMonitor: Any?
     private var rightMouseLocalMonitor: Any?
     private var rightMouseGlobalMonitor: Any?
-    private var preparationEscLocalMonitor: Any?
-    private var preparationEscGlobalMonitor: Any?
     private var editController: EditWindowController?
     private var activeSelectionView: SelectionView?
     private var activeScreen: NSScreen?
@@ -74,7 +75,20 @@ class OverlayWindowController {
     private var activeEditorContext: ActiveEditorContext?
     private var currentEditHistoryDraft: CurrentEditHistoryDraft?
     private let windowDetector = WindowDetector()
+    private let windowSnapshotLoader: WindowSnapshotLoader
+    private let windowImageLoader: WindowImageLoader
+    private let snapshotProvider: ScreenSnapshotProviding
+    private let triggerContext: CaptureTriggerContext?
+    private let onFirstFramePresented: (() -> Void)?
     private var screenSnapshots: [CGDirectDisplayID: CGImage] = [:]
+    private var selectionViewsByDisplayID: [CGDirectDisplayID: SelectionView] = [:]
+    private var expectedSnapshotDisplayIDs = Set<CGDirectDisplayID>()
+    private var failedSnapshotDisplayIDs = Set<CGDirectDisplayID>()
+    private var snapshotCancellation: ScreenSnapshotCancellation?
+    private var windowCaptureTask: Task<Void, Never>?
+    private var pendingWindowCapture: PendingWindowCapture?
+    private var snapshotCaptureFinished = false
+    private var pendingSelection: PendingSelection?
     private let onComplete: (NSImage?) -> Void
     private let onRequestFocusReturn: (() -> Void)?
     private let onRecordingSelection: ((NSRect, NSScreen) -> Void)?
@@ -90,10 +104,12 @@ class OverlayWindowController {
     private let suspendedDraft: SuspendedEditDraft?
     private let keepsEditorAcrossSpaces: Bool
     private var presentationScheduled = false
-    /// Bumped when a new prepare cycle starts or when cancelled mid-prepare so
-    /// stale background snapshot work never presents an overlay.
+    /// Bumped whenever a presentation starts or ends so stale asynchronous
+    /// snapshot/window-list callbacks cannot mutate a newer overlay session.
     private var presentationGeneration = 0
-    private var isPreparingOverlay = false
+    private var sessionEnded = false
+    private var firstFrameReported = false
+    private var firstFrameTargetDisplayID: CGDirectDisplayID?
 
     private struct ActiveEditorContext {
         let captureRect: CGRect
@@ -150,14 +166,59 @@ class OverlayWindowController {
         }
     }
 
+    private struct PendingSelection {
+        let rect: NSRect
+        let screenRect: NSRect
+        let captureRect: CGRect
+        let screen: NSScreen
+        let selectionView: SelectionView
+        let displayID: CGDirectDisplayID
+        let isWindowSelection: Bool
+        let windowID: CGWindowID?
+    }
+
+    private struct PendingWindowCapture {
+        let id: UUID
+        let generation: Int
+        let request: PendingSelection
+        let preSnapshot: CGImage?
+    }
+
     /// Route the default copy-to-clipboard hotkey (double-tap ⌘) into the
     /// editor while the overlay is active. No-op when the editor isn't up yet.
     func confirmFromKeyboard() {
         editController?.confirmFromKeyboard()
     }
 
+    static func prewarmPresentationSurfaces() {
+        OverlayPanelPool.shared.prewarm(screens: NSScreen.screens)
+    }
+
+    static func invalidateAndPrewarmPresentationSurfaces() {
+        OverlayPanelPool.shared.invalidateAndPrewarm(screens: NSScreen.screens)
+    }
+
+    func screenParametersDidChange() {
+        guard presentationScheduled,
+              !sessionEnded,
+              editController == nil else { return }
+        cancel()
+    }
+
     init(
         postCaptureAction: PostCaptureAction = .edit,
+        triggerContext: CaptureTriggerContext = CaptureTriggerContext(source: .programmatic),
+        snapshotProvider: ScreenSnapshotProviding = ScreenSnapshotProvider.shared,
+        windowSnapshotLoader: @escaping WindowSnapshotLoader = {
+            WindowDetector.snapshot(primaryScreenArea: $0)
+        },
+        windowImageLoader: @escaping WindowImageLoader = { windowID, pointSize in
+            try await ScreenCapturer.captureWindowAsync(
+                windowID: windowID,
+                pointSize: pointSize
+            )
+        },
+        onFirstFramePresented: (() -> Void)? = nil,
         onRecordingSelection: ((NSRect, NSScreen) -> Void)? = nil,
         onRequestFocusReturn: (() -> Void)? = nil,
         onSuspend: ((SuspendedEditDraft) -> Void)? = nil,
@@ -168,6 +229,11 @@ class OverlayWindowController {
         self.suspendedDraft = nil
         self.keepsEditorAcrossSpaces = false
         self.postCaptureAction = postCaptureAction
+        self.triggerContext = triggerContext
+        self.snapshotProvider = snapshotProvider
+        self.windowSnapshotLoader = windowSnapshotLoader
+        self.windowImageLoader = windowImageLoader
+        self.onFirstFramePresented = onFirstFramePresented
         self.onRecordingSelection = onRecordingSelection
         self.onRequestFocusReturn = onRequestFocusReturn
         self.onSuspend = onSuspend
@@ -187,6 +253,16 @@ class OverlayWindowController {
         self.suspendedDraft = nil
         self.keepsEditorAcrossSpaces = keepsEditorAcrossSpaces
         self.postCaptureAction = .edit
+        self.triggerContext = nil
+        self.snapshotProvider = ScreenSnapshotProvider.shared
+        self.windowSnapshotLoader = { WindowDetector.snapshot(primaryScreenArea: $0) }
+        self.windowImageLoader = { windowID, pointSize in
+            try await ScreenCapturer.captureWindowAsync(
+                windowID: windowID,
+                pointSize: pointSize
+            )
+        }
+        self.onFirstFramePresented = nil
         self.onRecordingSelection = nil
         self.onRequestFocusReturn = onRequestFocusReturn
         self.onSuspend = onSuspend
@@ -205,6 +281,16 @@ class OverlayWindowController {
         self.suspendedDraft = suspendedDraft
         self.keepsEditorAcrossSpaces = suspendedDraft.keepsEditorAcrossSpaces
         self.postCaptureAction = .edit
+        self.triggerContext = nil
+        self.snapshotProvider = ScreenSnapshotProvider.shared
+        self.windowSnapshotLoader = { WindowDetector.snapshot(primaryScreenArea: $0) }
+        self.windowImageLoader = { windowID, pointSize in
+            try await ScreenCapturer.captureWindowAsync(
+                windowID: windowID,
+                pointSize: pointSize
+            )
+        }
+        self.onFirstFramePresented = nil
         self.onRecordingSelection = onRecordingSelection
         self.onRequestFocusReturn = onRequestFocusReturn
         self.onSuspend = onSuspend
@@ -214,185 +300,166 @@ class OverlayWindowController {
     func activate() {
         guard !presentationScheduled else { return }
         presentationScheduled = true
-
-        let delay = ToastWindow.dismissForCaptureIfNeeded() ? 0.12 : 0
-        if delay > 0 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                self?.prepareAndPresentOverlay()
-            }
-        } else {
-            prepareAndPresentOverlay()
-        }
+        triggerContext?.mark(.activateRequested)
+        ToastWindow.dismiss()
+        beginOverlaySession()
     }
 
-    private func prepareAndPresentOverlay() {
-        // Window list + screen metadata must be sampled on the main thread.
-        // Full-display CGWindowListCreateImage is expensive (multi‑MB per
-        // Retina / 5K screen) and used to run serially on the main thread,
-        // which blocked the run loop and produced the spinning wait cursor
-        // before any selection overlay appeared.
-        windowDetector.refresh()
+    var isOverlayPresented: Bool {
+        !windows.isEmpty && windows.allSatisfy(\.isVisible)
+    }
 
-        let targets: [DisplayCaptureTarget] = NSScreen.screens.compactMap { screen in
-            guard let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
-                return nil
-            }
-            return DisplayCaptureTarget(displayID: displayID, bounds: CGDisplayBounds(displayID))
-        }
+    var isSelectionInteractive: Bool {
+        windows.compactMap { $0.contentView as? SelectionView }
+            .contains(where: \.selectionInteractionEnabled)
+    }
 
+    var activeSelectionViews: [SelectionView] {
+        windows.compactMap { $0.contentView as? SelectionView }
+    }
+
+    var isWaitingForSnapshot: Bool { pendingSelection != nil }
+    var isWaitingForWindowCapture: Bool { pendingWindowCapture != nil }
+    var appliedSnapshotCount: Int { screenSnapshots.count }
+    var hasActiveEditor: Bool { editController != nil }
+    var isCaptureSessionEnded: Bool { sessionEnded }
+
+    private func beginOverlaySession() {
         presentationGeneration += 1
         let generation = presentationGeneration
-        isPreparingOverlay = true
+        sessionEnded = false
         screenSnapshots.removeAll()
-        installPreparationCancelMonitors()
+        selectionViewsByDisplayID.removeAll()
+        failedSnapshotDisplayIDs.removeAll()
+        snapshotCaptureFinished = false
+        pendingSelection = nil
+        firstFrameReported = false
 
-        let prepareStarted = CFAbsoluteTimeGetCurrent()
+        let targets = Self.snapshotTargets()
+        expectedSnapshotDisplayIDs = Set(targets.map(\.displayID))
+        firstFrameTargetDisplayID = Self.displayIDUnderPointer()
+            ?? targets.first?.displayID
+        triggerContext?.mark(.backgroundPreparationStarted)
 
+        startWindowEnumeration(generation: generation)
+        startSnapshotCapture(targets: targets, generation: generation)
+        presentOverlay(generation: generation)
+    }
+
+    private func startSnapshotCapture(
+        targets: [ScreenSnapshotTarget],
+        generation: Int
+    ) {
+        guard shouldCaptureSnapshots,
+              generation == presentationGeneration,
+              !sessionEnded else { return }
+        triggerContext?.mark(.snapshotCaptureStarted)
+        let context = triggerContext
+        snapshotCancellation = snapshotProvider.capture(targets: targets) { [weak self] event in
+            context?.mark(.snapshotResultReady)
+            MainRunLoopScheduler.perform {
+                self?.handleSnapshotEvent(event, generation: generation)
+            }
+        }
+    }
+
+    private static func snapshotTargets() -> [ScreenSnapshotTarget] {
+        NSScreen.screens.compactMap { screen in
+            guard let displayID = screen.deviceDescription[
+                NSDeviceDescriptionKey("NSScreenNumber")
+            ] as? CGDirectDisplayID else { return nil }
+            return ScreenSnapshotTarget(
+                displayID: displayID,
+                bounds: CGDisplayBounds(displayID),
+                scale: screen.backingScaleFactor
+            )
+        }
+    }
+
+    private var shouldCaptureSnapshots: Bool {
+        guard presetImage == nil, suspendedDraft == nil else { return false }
+        if case .record = postCaptureAction { return false }
+        return true
+    }
+
+    private func startWindowEnumeration(generation: Int) {
+        guard presetImage == nil,
+              suspendedDraft == nil,
+              let primaryFrame = NSScreen.screens.first?.frame else { return }
+        let primaryScreenArea = primaryFrame.width * primaryFrame.height
+
+        let snapshotLoader = windowSnapshotLoader
+        let context = triggerContext
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let captured = Self.captureScreenSnapshots(targets: targets)
-            let captureMs = (CFAbsoluteTimeGetCurrent() - prepareStarted) * 1000
+            let result = snapshotLoader(primaryScreenArea)
+            context?.mark(.windowEnumerationReady)
+            MainRunLoopScheduler.perform {
+                guard let self,
+                      generation == self.presentationGeneration,
+                      !self.sessionEnded else { return }
+                self.triggerContext?.mark(.windowEnumerationApplied)
+                switch result {
+                case .success(let windows):
+                    self.windowDetector.apply(windows)
+                    for selectionView in self.selectionViewsByDisplayID.values {
+                        selectionView.refreshHoverAtCurrentMouseLocation()
+                    }
+                case .failure(let error):
+                    self.logPreparationFailure("window-enumeration", error: error)
+                }
+            }
+        }
+    }
 
-            DispatchQueue.main.async {
-                guard let self else { return }
-                // Cancelled or superseded by a newer prepare cycle.
-                guard generation == self.presentationGeneration, self.isPreparingOverlay else { return }
+    private func handleSnapshotEvent(_ event: ScreenSnapshotEvent, generation: Int) {
+        guard generation == presentationGeneration, !sessionEnded else { return }
+        triggerContext?.mark(.snapshotResultApplied)
 
-                self.removePreparationCancelMonitors()
-                self.isPreparingOverlay = false
-                self.screenSnapshots = captured.images
-
-                DiagnosticLog.log(
-                    "overlay-prepare",
-                    "screen-snapshots-ready",
-                    metadata: [
-                        "displayCount": targets.count,
-                        "capturedCount": captured.images.count,
-                        "captureMs": String(format: "%.1f", captureMs),
-                        "perDisplayMs": captured.perDisplayMs
-                            .map { "\($0.key)=\(String(format: "%.1f", $0.value))" }
-                            .sorted()
-                            .joined(separator: ","),
-                    ]
+        switch event {
+        case .image(let displayID, let image):
+            screenSnapshots[displayID] = image
+            if let selectionView = selectionViewsByDisplayID[displayID] {
+                selectionView.setBackgroundSnapshot(
+                    cgImage: image,
+                    pointSize: selectionView.bounds.size
                 )
-
-                self.finishPresentOverlayAfterPrepare()
+            }
+            resumePendingSelectionIfReady(displayID: displayID)
+        case .failure(let displayID, let error):
+            failedSnapshotDisplayIDs.insert(displayID)
+            logPreparationFailure("screen-snapshot-\(displayID)", error: error)
+            if pendingSelection?.displayID == displayID {
+                finishSelectionCaptureFailure()
+            }
+        case .finished:
+            snapshotCaptureFinished = true
+            if let pendingSelection,
+               screenSnapshots[pendingSelection.displayID] == nil {
+                finishSelectionCaptureFailure()
             }
         }
     }
 
-    private struct ScreenSnapshotCaptureResult {
-        let images: [CGDirectDisplayID: CGImage]
-        let perDisplayMs: [CGDirectDisplayID: Double]
-    }
-
-    private struct DisplayCaptureTarget {
-        let displayID: CGDirectDisplayID
-        let bounds: CGRect
-    }
-
-    /// Capture every display in parallel off the main thread.
-    private static func captureScreenSnapshots(
-        targets: [DisplayCaptureTarget]
-    ) -> ScreenSnapshotCaptureResult {
-        guard !targets.isEmpty else {
-            return ScreenSnapshotCaptureResult(images: [:], perDisplayMs: [:])
-        }
-
-        // Pre-capture all screen content before overlay panels appear,
-        // so transient menus and popups are preserved in the snapshot.
-        // Use CGWindowListCreateImage with .bestResolution so the image
-        // matches the display's effective resolution (not the native panel
-        // resolution), avoiding a visible scale shift on scaled displays.
-        let imagesBox = SnapshotDictionaryBox()
-        let timingBox = TimingDictionaryBox()
-
-        DispatchQueue.concurrentPerform(iterations: targets.count) { index in
-            let target = targets[index]
-            let started = CFAbsoluteTimeGetCurrent()
-            let image = CGWindowListCreateImage(
-                target.bounds,
-                .optionOnScreenOnly,
-                kCGNullWindowID,
-                .bestResolution
+    private func logPreparationFailure(_ operation: String, error: Error) {
+        let message = String(describing: error)
+        DispatchQueue.global(qos: .utility).async {
+            DiagnosticLog.log(
+                "overlay-prepare",
+                "async-preparation-failed",
+                metadata: ["operation": operation, "error": message]
             )
-            let elapsedMs = (CFAbsoluteTimeGetCurrent() - started) * 1000
-            timingBox.set(elapsedMs, for: target.displayID)
-            if let image {
-                imagesBox.set(image, for: target.displayID)
-            }
-        }
-
-        return ScreenSnapshotCaptureResult(
-            images: imagesBox.snapshot(),
-            perDisplayMs: timingBox.snapshot()
-        )
-    }
-
-    private func finishPresentOverlayAfterPrepare() {
-        if Self.isRunningEventTrackingMode {
-            Self.dismissActiveEventTrackingSurface()
-            MainRunLoopScheduler.performInDefaultMode { [weak self] in
-                self?.presentOverlay()
-            }
-        } else {
-            presentOverlay()
         }
     }
 
-    private func installPreparationCancelMonitors() {
-        removePreparationCancelMonitors()
-        preparationEscLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == 53 {
-                self?.cancelDuringPreparation()
-                return nil
-            }
-            return event
-        }
-        preparationEscGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == 53 {
-                self?.cancelDuringPreparation()
-            }
-        }
-    }
-
-    private func removePreparationCancelMonitors() {
-        if let monitor = preparationEscLocalMonitor {
-            NSEvent.removeMonitor(monitor)
-            preparationEscLocalMonitor = nil
-        }
-        if let monitor = preparationEscGlobalMonitor {
-            NSEvent.removeMonitor(monitor)
-            preparationEscGlobalMonitor = nil
-        }
-    }
-
-    private func cancelDuringPreparation() {
-        guard isPreparingOverlay else { return }
-        presentationGeneration += 1
-        isPreparingOverlay = false
-        removePreparationCancelMonitors()
-        screenSnapshots.removeAll()
-        // Crosshair is only pushed once presentOverlay runs; skip the matching
-        // pop so cancel-during-prepare does not unbalance the cursor stack.
-        cursorPopped = true
-        tearDown()
-        onComplete(nil)
-        onRequestFocusReturn?()
-    }
-
-    private func presentOverlay() {
+    private func presentOverlay(generation: Int) {
         guard windows.isEmpty else { return }
-        let presentStarted = CFAbsoluteTimeGetCurrent()
 
-        // Create all overlay windows and seed snapshot layers before showing
-        // any of them, so there is no visible flash or zoom.
+        // The transparent selection shell is deliberately created without
+        // waiting for frozen pixels. Until a snapshot arrives, AppKit simply
+        // reveals the live desktop through the clear panel.
         for screen in NSScreen.screens {
-            let window = OverlayPanel(
-                contentRect: screen.frame,
-                styleMask: [.borderless, .nonactivatingPanel],
-                backing: .buffered,
-                defer: false
-            )
+            let window = OverlayPanelPool.shared.lease(for: screen)
+            let surfacePresentationToken = window.surfacePresentationToken
             window.level = .screenSaver
             window.isOpaque = false
             window.backgroundColor = .clear
@@ -406,45 +473,47 @@ class OverlayWindowController {
             selectionView.delegate = self
             selectionView.windowDetector = windowDetector
             selectionView.aspectRatio = usesAspectRatioSelection ? Self.persistedSelectionAspectRatio : nil
+            selectionView.onFirstDrawCompleted = { [weak self] in
+                self?.recordFirstDraw(generation: generation)
+            }
+            selectionView.onFirstFramePresented = { [weak self] in
+                guard OverlayPanelPool.shared.markSurfacePresented(
+                    window,
+                    for: screen,
+                    presentationToken: surfacePresentationToken
+                ) else { return }
+                let displayID = screen.deviceDescription[
+                    NSDeviceDescriptionKey("NSScreenNumber")
+                ] as? CGDirectDisplayID
+                self?.recordFirstFrame(
+                    generation: generation,
+                    displayID: displayID
+                )
+            }
             if let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
                let snapshot = screenSnapshots[displayID] {
                 selectionView.setBackgroundSnapshot(cgImage: snapshot, pointSize: screen.frame.size)
             }
             window.contentView = selectionView
 
-            // Pre-render the snapshot into the backing store before the window
-            // becomes visible, so the first on-screen frame already has content.
-            // Runs on the main thread but only after off-main capture completes,
-            // so the earlier multi-second beachball from CGWindowListCreateImage
-            // no longer blocks the run loop.
-            selectionView.display()
+            if let displayID = screen.deviceDescription[
+                NSDeviceDescriptionKey("NSScreenNumber")
+            ] as? CGDirectDisplayID {
+                selectionViewsByDisplayID[displayID] = selectionView
+            }
 
             windows.append(window)
         }
 
         // Show all overlay windows in one batch with animations disabled.
+        triggerContext?.mark(.overlayInitialized)
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         for window in windows {
-            window.orderFront(nil)
+            window.orderFrontRegardless()
         }
-        windows.first?.makeKey()
         CATransaction.commit()
-
-        DiagnosticLog.log(
-            "overlay-prepare",
-            "overlay-presented",
-            metadata: [
-                "windowCount": windows.count,
-                "presentMs": String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - presentStarted) * 1000),
-            ]
-        )
-
-        if presetImage == nil, suspendedDraft == nil {
-            for case let selectionView as SelectionView in windows.compactMap(\.contentView) {
-                selectionView.refreshHoverAtCurrentMouseLocation()
-            }
-        }
+        triggerContext?.mark(.overlayOrderedFront)
 
         chipWindow = CursorChipWindow(text: currentCursorChipText)
         chipWindow?.show()
@@ -518,6 +587,7 @@ class OverlayWindowController {
 
         if presetImage == nil, suspendedDraft == nil {
             NSCursor.crosshair.push()
+            cursorWasPushed = true
         } else {
             // Skip cursor push so tearDown's pop doesn't strip an unrelated cursor.
             cursorPopped = true
@@ -530,6 +600,36 @@ class OverlayWindowController {
                 enterPresetSelection()
             }
         }
+    }
+
+    private func recordFirstDraw(generation: Int) {
+        guard generation == presentationGeneration, !sessionEnded else { return }
+        triggerContext?.mark(.firstDrawCompleted)
+    }
+
+    private func recordFirstFrame(
+        generation: Int,
+        displayID: CGDirectDisplayID?
+    ) {
+        guard generation == presentationGeneration,
+              !sessionEnded,
+              !firstFrameReported,
+              firstFrameTargetDisplayID == nil
+                || displayID == firstFrameTargetDisplayID else { return }
+        firstFrameReported = true
+        triggerContext?.mark(.firstFrame)
+        triggerContext?.finish(.presented)
+        onFirstFramePresented?()
+    }
+
+    private static func displayIDUnderPointer() -> CGDirectDisplayID? {
+        let pointer = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(pointer) }
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        return screen?.deviceDescription[
+            NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? CGDirectDisplayID
     }
 
     private static var persistedSelectionAspectRatio: CGFloat? {
@@ -626,25 +726,6 @@ class OverlayWindowController {
             selectionView.aspectRatio = aspectRatio
         }
         activeSelectionView?.aspectRatio = aspectRatio
-    }
-
-    private static var isRunningEventTrackingMode: Bool {
-        guard let mode = CFRunLoopCopyCurrentMode(CFRunLoopGetMain()) else {
-            return false
-        }
-        return mode.rawValue as String == RunLoop.Mode.eventTracking.rawValue
-    }
-
-    private static func dismissActiveEventTrackingSurface() {
-        NSApp.sendAction(#selector(NSResponder.cancelOperation(_:)), to: nil, from: nil)
-
-        let source = CGEventSource(stateID: .combinedSessionState)
-        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 53, keyDown: true)
-        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 53, keyDown: false)
-        keyDown?.flags = []
-        keyUp?.flags = []
-        keyDown?.post(tap: .cghidEventTap)
-        keyUp?.post(tap: .cghidEventTap)
     }
 
     /// Image-edit mode: pick the screen under the cursor, place a centered
@@ -817,10 +898,8 @@ class OverlayWindowController {
     }
 
     func cancel() {
-        if isPreparingOverlay {
-            cancelDuringPreparation()
-            return
-        }
+        guard !sessionEnded else { return }
+        triggerContext?.finish(.cancelled)
         editController?.tearDown()
         editController = nil
         tearDown()
@@ -866,17 +945,25 @@ class OverlayWindowController {
     }
 
     private var cursorPopped = false
+    private var cursorWasPushed = false
 
     private func tearDown() {
+        guard !sessionEnded else { return }
+        sessionEnded = true
+        presentationGeneration += 1
+        snapshotCancellation?()
+        snapshotCancellation = nil
+        windowCaptureTask?.cancel()
+        windowCaptureTask = nil
+        pendingWindowCapture = nil
+        pendingSelection = nil
         ToastWindow.dismiss()
 
-        isPreparingOverlay = false
-        removePreparationCancelMonitors()
-
-        if !cursorPopped {
+        if cursorWasPushed, !cursorPopped {
             NSCursor.pop()
             cursorPopped = true
         }
+        cursorWasPushed = false
 
         chipWindow?.dismiss()
         chipWindow = nil
@@ -887,10 +974,16 @@ class OverlayWindowController {
         if let m = rightMouseGlobalMonitor { NSEvent.removeMonitor(m); rightMouseGlobalMonitor = nil }
 
         for window in windows {
-            window.orderOut(nil)
+            (window.contentView as? SelectionView)?.cancelFirstFramePresentationTracking()
+            OverlayPanelPool.shared.recycle(window)
         }
         windows.removeAll()
         screenSnapshots.removeAll()
+        selectionViewsByDisplayID.removeAll()
+        expectedSnapshotDisplayIDs.removeAll()
+        failedSnapshotDisplayIDs.removeAll()
+        snapshotCaptureFinished = false
+        firstFrameTargetDisplayID = nil
         activeSelectionView = nil
         activeScreen = nil
         activeEditorContext = nil
@@ -950,91 +1043,7 @@ extension OverlayWindowController: SelectionViewDelegate {
         let screenRect = convertToScreenRect(rect, view: view)
         let cgRect = convertToCGRect(screenRect)
 
-        if editController == nil {
-            // Lock selection so clicking outside won't reset it
-            for case let selectionView as SelectionView in windows.compactMap(\.contentView) {
-                selectionView.selectionLocked = true
-            }
-
-            // Keep only the active screen overlay alive for editing. Other
-            // screens can stop intercepting input once the region is chosen.
-            for existingWindow in windows where existingWindow != window {
-                existingWindow.orderOut(nil)
-            }
-
-            // Pop the crosshair cursor pushed during activate(). In image-edit
-            // (preset) mode we never pushed one, so the flag handles that.
-            if !cursorPopped {
-                NSCursor.pop()
-                cursorPopped = true
-            }
-
-            // First time selection complete — show editor
-            let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
-            let preSnapshot = displayID.flatMap { screenSnapshots[$0] }
-            let windowBaseImage = imageForWindowSelection(
-                isWindowSelection: isWindowSelection,
-                windowID: windowID,
-                pointSize: rect.size,
-                captureRect: cgRect,
-                screen: screen,
-                preSnapshot: preSnapshot
-            )
-            let shouldApplyWindowEffects = isWindowSelection && windowBaseImage != nil
-
-            switch postCaptureAction {
-            case .edit:
-                break
-            case .textRecognition, .copyImageText, .screenshotTranslation:
-                let baseImage = imageForImmediateAction(
-                    captureRect: cgRect,
-                    screen: screen,
-                    preSnapshot: preSnapshot,
-                    windowBaseImage: windowBaseImage
-                )
-                tearDown()
-                onComplete(nil)
-                guard let baseImage else { return }
-                switch postCaptureAction {
-                case .edit:
-                    break
-                case .textRecognition:
-                    OCRTranslatePanel.presentTextRecognition(
-                        image: baseImage, anchorRect: screenRect, screen: screen
-                    )
-                case .copyImageText:
-                    copyRecognizedTextToClipboard(
-                        from: baseImage,
-                        screen: screen,
-                        anchorRect: screenRect
-                    )
-                case .screenshotTranslation:
-                    OCRTranslatePanel.presentScreenshotTranslation(
-                        image: baseImage, anchorRect: screenRect, screen: screen
-                    )
-                case .record:
-                    break
-                }
-                return
-            case .record:
-                tearDown()
-                onComplete(nil)
-                onRecordingSelection?(screenRect, screen)
-                return
-            }
-
-            showEditor(
-                captureRect: cgRect,
-                screen: screen,
-                selectionRect: screenRect,
-                selectionViewRect: rect,
-                hostSelectionView: selectionView,
-                preSnapshot: preSnapshot,
-                overrideBaseImage: presetImage,
-                windowBaseImage: windowBaseImage,
-                isWindowCapture: shouldApplyWindowEffects
-            )
-        } else {
+        if editController != nil {
             // Selection was adjusted — it no longer matches the clicked
             // window's bounds, so window-only effects no longer apply.
             historyEntryIndex = nil
@@ -1046,7 +1055,251 @@ extension OverlayWindowController: SelectionViewDelegate {
                 selectionViewRect: rect,
                 captureRect: cgRect
             )
+            return
         }
+
+        guard !sessionEnded else { return }
+        lockSelectionForCompletion(activeWindow: window)
+
+        guard let displayID = screen.deviceDescription[
+            NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? CGDirectDisplayID else {
+            finishSelectionCaptureFailure()
+            return
+        }
+
+        let request = PendingSelection(
+            rect: rect,
+            screenRect: screenRect,
+            captureRect: cgRect,
+            screen: screen,
+            selectionView: selectionView,
+            displayID: displayID,
+            isWindowSelection: isWindowSelection,
+            windowID: windowID
+        )
+
+        guard shouldCaptureSnapshots else {
+            completeInitialSelection(request, preSnapshot: nil)
+            return
+        }
+        if let snapshot = screenSnapshots[displayID] {
+            completeInitialSelection(request, preSnapshot: snapshot)
+            return
+        }
+        guard expectedSnapshotDisplayIDs.contains(displayID),
+              !failedSnapshotDisplayIDs.contains(displayID),
+              !snapshotCaptureFinished else {
+            finishSelectionCaptureFailure()
+            return
+        }
+
+        selectionView.selectionInteractionEnabled = false
+        pendingSelection = request
+    }
+
+    private func lockSelectionForCompletion(activeWindow: NSWindow) {
+        for case let selectionView as SelectionView in windows.compactMap(\.contentView) {
+            selectionView.selectionLocked = true
+        }
+        for existingWindow in windows where existingWindow != activeWindow {
+            existingWindow.orderOut(nil)
+        }
+        if cursorWasPushed, !cursorPopped {
+            NSCursor.pop()
+            cursorPopped = true
+        }
+    }
+
+    private func resumePendingSelectionIfReady(displayID: CGDirectDisplayID) {
+        guard let request = pendingSelection,
+              request.displayID == displayID,
+              let snapshot = screenSnapshots[displayID] else { return }
+        pendingSelection = nil
+        request.selectionView.selectionInteractionEnabled = true
+        completeInitialSelection(request, preSnapshot: snapshot)
+    }
+
+    private func completeInitialSelection(
+        _ request: PendingSelection,
+        preSnapshot: CGImage?
+    ) {
+        guard !sessionEnded else { return }
+        if let windowID = directWindowCaptureID(for: request, preSnapshot: preSnapshot) {
+            startWindowCapture(
+                windowID: windowID,
+                request: request,
+                preSnapshot: preSnapshot
+            )
+            return
+        }
+        finishInitialSelection(request, preSnapshot: preSnapshot, directWindowImage: nil)
+    }
+
+    private func directWindowCaptureID(
+        for request: PendingSelection,
+        preSnapshot: CGImage?
+    ) -> CGWindowID? {
+        guard request.isWindowSelection, let windowID = request.windowID else { return nil }
+        if preSnapshot != nil,
+           windowDetector.usesCompositedScreenBackdrop(forWindowID: windowID) {
+            return nil
+        }
+        return windowID
+    }
+
+    private func startWindowCapture(
+        windowID: CGWindowID,
+        request: PendingSelection,
+        preSnapshot: CGImage?
+    ) {
+        request.selectionView.selectionInteractionEnabled = false
+        let generation = presentationGeneration
+        let captureID = UUID()
+        let pointSize = request.rect.size
+        let windowImageLoader = windowImageLoader
+        pendingWindowCapture = PendingWindowCapture(
+            id: captureID,
+            generation: generation,
+            request: request,
+            preSnapshot: preSnapshot
+        )
+        windowCaptureTask = Task.detached(priority: .userInitiated) { [weak self] in
+            let result: Result<NSImage?, Error>
+            do {
+                result = .success(try await windowImageLoader(windowID, pointSize))
+            } catch {
+                result = .failure(error)
+            }
+            guard !Task.isCancelled else { return }
+            MainRunLoopScheduler.perform {
+                self?.finishWindowCapture(
+                    result,
+                    captureID: captureID,
+                    generation: generation
+                )
+            }
+        }
+    }
+
+    private func finishWindowCapture(
+        _ result: Result<NSImage?, Error>,
+        captureID: UUID,
+        generation: Int
+    ) {
+        guard generation == presentationGeneration,
+              !sessionEnded,
+              let pendingWindowCapture,
+              pendingWindowCapture.id == captureID,
+              pendingWindowCapture.generation == generation else { return }
+        windowCaptureTask = nil
+        self.pendingWindowCapture = nil
+        let request = pendingWindowCapture.request
+        let preSnapshot = pendingWindowCapture.preSnapshot
+        request.selectionView.selectionInteractionEnabled = true
+
+        switch result {
+        case .success(let image):
+            finishInitialSelection(
+                request,
+                preSnapshot: preSnapshot,
+                directWindowImage: image
+            )
+        case .failure(let error):
+            logPreparationFailure("window-snapshot-\(request.windowID ?? 0)", error: error)
+            finishInitialSelection(
+                request,
+                preSnapshot: preSnapshot,
+                directWindowImage: nil
+            )
+        }
+    }
+
+    private func finishInitialSelection(
+        _ request: PendingSelection,
+        preSnapshot: CGImage?,
+        directWindowImage: NSImage?
+    ) {
+        let windowBaseImage = imageForWindowSelection(
+            isWindowSelection: request.isWindowSelection,
+            captureRect: request.captureRect,
+            screen: request.screen,
+            preSnapshot: preSnapshot,
+            directWindowImage: directWindowImage
+        )
+        let shouldApplyWindowEffects = request.isWindowSelection && windowBaseImage != nil
+
+        switch postCaptureAction {
+        case .edit:
+            showEditor(
+                captureRect: request.captureRect,
+                screen: request.screen,
+                selectionRect: request.screenRect,
+                selectionViewRect: request.rect,
+                hostSelectionView: request.selectionView,
+                preSnapshot: preSnapshot,
+                overrideBaseImage: presetImage,
+                windowBaseImage: windowBaseImage,
+                isWindowCapture: shouldApplyWindowEffects
+            )
+        case .textRecognition, .copyImageText, .screenshotTranslation:
+            completeImmediateAction(request, preSnapshot: preSnapshot, windowBaseImage: windowBaseImage)
+        case .record:
+            tearDown()
+            onComplete(nil)
+            onRecordingSelection?(request.screenRect, request.screen)
+        }
+    }
+
+    private func completeImmediateAction(
+        _ request: PendingSelection,
+        preSnapshot: CGImage?,
+        windowBaseImage: NSImage?
+    ) {
+        let baseImage = imageForImmediateAction(
+            captureRect: request.captureRect,
+            screen: request.screen,
+            preSnapshot: preSnapshot,
+            windowBaseImage: windowBaseImage
+        )
+        tearDown()
+        onComplete(nil)
+        guard let baseImage else {
+            ToastWindow.show(message: L10n.fullScreenScreenshotFailed)
+            return
+        }
+
+        switch postCaptureAction {
+        case .textRecognition:
+            OCRTranslatePanel.presentTextRecognition(
+                image: baseImage,
+                anchorRect: request.screenRect,
+                screen: request.screen
+            )
+        case .copyImageText:
+            copyRecognizedTextToClipboard(
+                from: baseImage,
+                screen: request.screen,
+                anchorRect: request.screenRect
+            )
+        case .screenshotTranslation:
+            OCRTranslatePanel.presentScreenshotTranslation(
+                image: baseImage,
+                anchorRect: request.screenRect,
+                screen: request.screen
+            )
+        case .edit, .record:
+            break
+        }
+    }
+
+    private func finishSelectionCaptureFailure() {
+        guard !sessionEnded else { return }
+        triggerContext?.finish(.failed)
+        tearDown()
+        onComplete(nil)
+        onRequestFocusReturn?()
+        ToastWindow.show(message: L10n.fullScreenScreenshotFailed)
     }
 
     private func showEditor(
@@ -1317,12 +1570,7 @@ extension OverlayWindowController: SelectionViewDelegate {
         if let preSnapshot {
             return ScreenCapturer.crop(from: preSnapshot, captureRect: captureRect, screen: screen)
         }
-        let overlayWindowIDs = windows.map { CGWindowID($0.windowNumber) }
-        return ScreenCapturer.capture(
-            rect: captureRect,
-            screen: screen,
-            excludingWindowNumbers: overlayWindowIDs
-        )
+        return nil
     }
 
     private func copyRecognizedTextToClipboard(from image: NSImage, screen: NSScreen, anchorRect: NSRect) {
@@ -1357,32 +1605,14 @@ extension OverlayWindowController: SelectionViewDelegate {
 
     private func imageForWindowSelection(
         isWindowSelection: Bool,
-        windowID: CGWindowID?,
-        pointSize: NSSize,
         captureRect: CGRect,
         screen: NSScreen,
-        preSnapshot: CGImage?
+        preSnapshot: CGImage?,
+        directWindowImage: NSImage?
     ) -> NSImage? {
         guard isWindowSelection else { return nil }
-
-        // High-layer system surfaces such as menus and popups are often only
-        // translucent foreground windows. Keep those on the composited screen
-        // backdrop path when a pre-overlay snapshot is available.
-        if preSnapshot != nil,
-           windowID.map({ windowDetector.usesCompositedScreenBackdrop(forWindowID: $0) }) == true {
-            return nil
-        }
-
-        var directWindowImage: NSImage?
-        if let windowID {
-            let captured = ScreenCapturer.capture(windowID: windowID, pointSize: pointSize)
-
-            if let captured {
-                let transparent = ScreenCapturer.isEffectivelyTransparent(captured)
-                if !transparent {
-                    directWindowImage = captured
-                }
-            }
+        let usableDirectImage = directWindowImage.flatMap { image in
+            ScreenCapturer.isEffectivelyTransparent(image) ? nil : image
         }
 
         if let snapshotWindowImage = preSnapshotImage(
@@ -1390,8 +1620,8 @@ extension OverlayWindowController: SelectionViewDelegate {
             screen: screen,
             preSnapshot: preSnapshot
         ) {
-            if let directWindowImage {
-                let maskedImage = WindowEffects.applyingAlphaMask(from: directWindowImage, to: snapshotWindowImage)
+            if let usableDirectImage {
+                let maskedImage = WindowEffects.applyingAlphaMask(from: usableDirectImage, to: snapshotWindowImage)
                 if let maskedImage {
                     return maskedImage
                 }
@@ -1399,7 +1629,7 @@ extension OverlayWindowController: SelectionViewDelegate {
             return WindowEffects.roundedCorners(snapshotWindowImage)
         }
 
-        return directWindowImage
+        return usableDirectImage
     }
 
     private func preSnapshotImage(
@@ -1422,50 +1652,4 @@ extension OverlayWindowController: SelectionViewDelegate {
 
         return ScreenCapturer.crop(from: preSnapshot, captureRect: captureRect, screen: screen)
     }
-}
-
-// MARK: - Thread-safe snapshot collectors
-
-/// Holds per-display CGImages produced by concurrent capture workers.
-private final class SnapshotDictionaryBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var values: [CGDirectDisplayID: CGImage] = [:]
-
-    func set(_ image: CGImage, for displayID: CGDirectDisplayID) {
-        lock.lock()
-        values[displayID] = image
-        lock.unlock()
-    }
-
-    func snapshot() -> [CGDirectDisplayID: CGImage] {
-        lock.lock()
-        defer { lock.unlock() }
-        return values
-    }
-}
-
-/// Holds per-display capture timings from concurrent workers.
-private final class TimingDictionaryBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var values: [CGDirectDisplayID: Double] = [:]
-
-    func set(_ milliseconds: Double, for displayID: CGDirectDisplayID) {
-        lock.lock()
-        values[displayID] = milliseconds
-        lock.unlock()
-    }
-
-    func snapshot() -> [CGDirectDisplayID: Double] {
-        lock.lock()
-        defer { lock.unlock() }
-        return values
-    }
-}
-
-// MARK: - Non-activating Overlay Panel
-
-/// A borderless panel that becomes key without activating the app,
-/// so other apps' transient popups (menus, download panels, etc.) stay visible.
-private class OverlayPanel: NSPanel {
-    override var canBecomeKey: Bool { true }
 }

--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -63,6 +63,8 @@ class OverlayWindowController {
     private var escGlobalMonitor: Any?
     private var rightMouseLocalMonitor: Any?
     private var rightMouseGlobalMonitor: Any?
+    private var preparationEscLocalMonitor: Any?
+    private var preparationEscGlobalMonitor: Any?
     private var editController: EditWindowController?
     private var activeSelectionView: SelectionView?
     private var activeScreen: NSScreen?
@@ -88,6 +90,10 @@ class OverlayWindowController {
     private let suspendedDraft: SuspendedEditDraft?
     private let keepsEditorAcrossSpaces: Bool
     private var presentationScheduled = false
+    /// Bumped when a new prepare cycle starts or when cancelled mid-prepare so
+    /// stale background snapshot work never presents an overlay.
+    private var presentationGeneration = 0
+    private var isPreparingOverlay = false
 
     private struct ActiveEditorContext {
         let captureRect: CGRect
@@ -220,8 +226,109 @@ class OverlayWindowController {
     }
 
     private func prepareAndPresentOverlay() {
-        prepareScreenContext()
+        // Window list + screen metadata must be sampled on the main thread.
+        // Full-display CGWindowListCreateImage is expensive (multi‑MB per
+        // Retina / 5K screen) and used to run serially on the main thread,
+        // which blocked the run loop and produced the spinning wait cursor
+        // before any selection overlay appeared.
+        windowDetector.refresh()
 
+        let targets: [DisplayCaptureTarget] = NSScreen.screens.compactMap { screen in
+            guard let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+                return nil
+            }
+            return DisplayCaptureTarget(displayID: displayID, bounds: CGDisplayBounds(displayID))
+        }
+
+        presentationGeneration += 1
+        let generation = presentationGeneration
+        isPreparingOverlay = true
+        screenSnapshots.removeAll()
+        installPreparationCancelMonitors()
+
+        let prepareStarted = CFAbsoluteTimeGetCurrent()
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let captured = Self.captureScreenSnapshots(targets: targets)
+            let captureMs = (CFAbsoluteTimeGetCurrent() - prepareStarted) * 1000
+
+            DispatchQueue.main.async {
+                guard let self else { return }
+                // Cancelled or superseded by a newer prepare cycle.
+                guard generation == self.presentationGeneration, self.isPreparingOverlay else { return }
+
+                self.removePreparationCancelMonitors()
+                self.isPreparingOverlay = false
+                self.screenSnapshots = captured.images
+
+                DiagnosticLog.log(
+                    "overlay-prepare",
+                    "screen-snapshots-ready",
+                    metadata: [
+                        "displayCount": targets.count,
+                        "capturedCount": captured.images.count,
+                        "captureMs": String(format: "%.1f", captureMs),
+                        "perDisplayMs": captured.perDisplayMs
+                            .map { "\($0.key)=\(String(format: "%.1f", $0.value))" }
+                            .sorted()
+                            .joined(separator: ","),
+                    ]
+                )
+
+                self.finishPresentOverlayAfterPrepare()
+            }
+        }
+    }
+
+    private struct ScreenSnapshotCaptureResult {
+        let images: [CGDirectDisplayID: CGImage]
+        let perDisplayMs: [CGDirectDisplayID: Double]
+    }
+
+    private struct DisplayCaptureTarget {
+        let displayID: CGDirectDisplayID
+        let bounds: CGRect
+    }
+
+    /// Capture every display in parallel off the main thread.
+    private static func captureScreenSnapshots(
+        targets: [DisplayCaptureTarget]
+    ) -> ScreenSnapshotCaptureResult {
+        guard !targets.isEmpty else {
+            return ScreenSnapshotCaptureResult(images: [:], perDisplayMs: [:])
+        }
+
+        // Pre-capture all screen content before overlay panels appear,
+        // so transient menus and popups are preserved in the snapshot.
+        // Use CGWindowListCreateImage with .bestResolution so the image
+        // matches the display's effective resolution (not the native panel
+        // resolution), avoiding a visible scale shift on scaled displays.
+        let imagesBox = SnapshotDictionaryBox()
+        let timingBox = TimingDictionaryBox()
+
+        DispatchQueue.concurrentPerform(iterations: targets.count) { index in
+            let target = targets[index]
+            let started = CFAbsoluteTimeGetCurrent()
+            let image = CGWindowListCreateImage(
+                target.bounds,
+                .optionOnScreenOnly,
+                kCGNullWindowID,
+                .bestResolution
+            )
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - started) * 1000
+            timingBox.set(elapsedMs, for: target.displayID)
+            if let image {
+                imagesBox.set(image, for: target.displayID)
+            }
+        }
+
+        return ScreenSnapshotCaptureResult(
+            images: imagesBox.snapshot(),
+            perDisplayMs: timingBox.snapshot()
+        )
+    }
+
+    private func finishPresentOverlayAfterPrepare() {
         if Self.isRunningEventTrackingMode {
             Self.dismissActiveEventTrackingSurface()
             MainRunLoopScheduler.performInDefaultMode { [weak self] in
@@ -232,37 +339,53 @@ class OverlayWindowController {
         }
     }
 
-    private func prepareScreenContext() {
-        let screens = NSScreen.screens
-
-        // Snapshot visible windows before our overlays appear
-        windowDetector.refresh()
-
-        // Pre-capture all screen content before overlay panels appear,
-        // so transient menus and popups are preserved in the snapshot.
-        // Use CGWindowListCreateImage with .bestResolution so the image
-        // matches the display's effective resolution (not the native panel
-        // resolution), avoiding a visible scale shift on scaled displays.
-        screenSnapshots.removeAll()
-        for screen in screens {
-            if let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID {
-                let displayBounds = CGDisplayBounds(displayID)
-                if let image = CGWindowListCreateImage(
-                    displayBounds,
-                    .optionOnScreenOnly,
-                    kCGNullWindowID,
-                    .bestResolution
-                ) {
-                    screenSnapshots[displayID] = image
-                }
+    private func installPreparationCancelMonitors() {
+        removePreparationCancelMonitors()
+        preparationEscLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 {
+                self?.cancelDuringPreparation()
+                return nil
+            }
+            return event
+        }
+        preparationEscGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 {
+                self?.cancelDuringPreparation()
             }
         }
     }
 
+    private func removePreparationCancelMonitors() {
+        if let monitor = preparationEscLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            preparationEscLocalMonitor = nil
+        }
+        if let monitor = preparationEscGlobalMonitor {
+            NSEvent.removeMonitor(monitor)
+            preparationEscGlobalMonitor = nil
+        }
+    }
+
+    private func cancelDuringPreparation() {
+        guard isPreparingOverlay else { return }
+        presentationGeneration += 1
+        isPreparingOverlay = false
+        removePreparationCancelMonitors()
+        screenSnapshots.removeAll()
+        // Crosshair is only pushed once presentOverlay runs; skip the matching
+        // pop so cancel-during-prepare does not unbalance the cursor stack.
+        cursorPopped = true
+        tearDown()
+        onComplete(nil)
+        onRequestFocusReturn?()
+    }
+
     private func presentOverlay() {
         guard windows.isEmpty else { return }
-        // Create all overlay windows and pre-render their content before
-        // showing any of them, so there is no visible flash or zoom.
+        let presentStarted = CFAbsoluteTimeGetCurrent()
+
+        // Create all overlay windows and seed snapshot layers before showing
+        // any of them, so there is no visible flash or zoom.
         for screen in NSScreen.screens {
             let window = OverlayPanel(
                 contentRect: screen.frame,
@@ -285,12 +408,15 @@ class OverlayWindowController {
             selectionView.aspectRatio = usesAspectRatioSelection ? Self.persistedSelectionAspectRatio : nil
             if let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
                let snapshot = screenSnapshots[displayID] {
-                selectionView.backgroundSnapshot = NSImage(cgImage: snapshot, size: screen.frame.size)
+                selectionView.setBackgroundSnapshot(cgImage: snapshot, pointSize: screen.frame.size)
             }
             window.contentView = selectionView
 
             // Pre-render the snapshot into the backing store before the window
             // becomes visible, so the first on-screen frame already has content.
+            // Runs on the main thread but only after off-main capture completes,
+            // so the earlier multi-second beachball from CGWindowListCreateImage
+            // no longer blocks the run loop.
             selectionView.display()
 
             windows.append(window)
@@ -304,6 +430,15 @@ class OverlayWindowController {
         }
         windows.first?.makeKey()
         CATransaction.commit()
+
+        DiagnosticLog.log(
+            "overlay-prepare",
+            "overlay-presented",
+            metadata: [
+                "windowCount": windows.count,
+                "presentMs": String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - presentStarted) * 1000),
+            ]
+        )
 
         if presetImage == nil, suspendedDraft == nil {
             for case let selectionView as SelectionView in windows.compactMap(\.contentView) {
@@ -682,6 +817,10 @@ class OverlayWindowController {
     }
 
     func cancel() {
+        if isPreparingOverlay {
+            cancelDuringPreparation()
+            return
+        }
         editController?.tearDown()
         editController = nil
         tearDown()
@@ -730,6 +869,9 @@ class OverlayWindowController {
 
     private func tearDown() {
         ToastWindow.dismiss()
+
+        isPreparingOverlay = false
+        removePreparationCancelMonitors()
 
         if !cursorPopped {
             NSCursor.pop()
@@ -1279,6 +1421,44 @@ extension OverlayWindowController: SelectionViewDelegate {
         }
 
         return ScreenCapturer.crop(from: preSnapshot, captureRect: captureRect, screen: screen)
+    }
+}
+
+// MARK: - Thread-safe snapshot collectors
+
+/// Holds per-display CGImages produced by concurrent capture workers.
+private final class SnapshotDictionaryBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [CGDirectDisplayID: CGImage] = [:]
+
+    func set(_ image: CGImage, for displayID: CGDirectDisplayID) {
+        lock.lock()
+        values[displayID] = image
+        lock.unlock()
+    }
+
+    func snapshot() -> [CGDirectDisplayID: CGImage] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+/// Holds per-display capture timings from concurrent workers.
+private final class TimingDictionaryBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [CGDirectDisplayID: Double] = [:]
+
+    func set(_ milliseconds: Double, for displayID: CGDirectDisplayID) {
+        lock.lock()
+        values[displayID] = milliseconds
+        lock.unlock()
+    }
+
+    func snapshot() -> [CGDirectDisplayID: Double] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
     }
 }
 

--- a/capcap/Capture/ScreenCapturer.swift
+++ b/capcap/Capture/ScreenCapturer.swift
@@ -65,9 +65,8 @@ struct ScreenCapturer {
         }
     }
 
-    /// Capture one WindowServer window directly, preserving its real alpha
-    /// silhouette. This gives window screenshots the exact system corner mask
-    /// instead of relying on a guessed radius.
+    /// Synchronous bridge retained for the headless agent command, which runs
+    /// capture work outside the interactive overlay path.
     static func capture(
         windowID: CGWindowID,
         pointSize: NSSize? = nil,
@@ -192,7 +191,7 @@ struct ScreenCapturer {
         )
     }
 
-    private static func captureWindowAsync(windowID: CGWindowID, pointSize: NSSize?) async throws -> NSImage? {
+    static func captureWindowAsync(windowID: CGWindowID, pointSize: NSSize?) async throws -> NSImage? {
         let content = try await SCShareableContent.current
         guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
             return nil

--- a/capcap/Capture/ScreenSnapshotProvider.swift
+++ b/capcap/Capture/ScreenSnapshotProvider.swift
@@ -1,0 +1,410 @@
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+struct ScreenSnapshotTarget: Sendable {
+    let displayID: CGDirectDisplayID
+    let bounds: CGRect
+    let scale: CGFloat
+}
+
+enum ScreenSnapshotEvent: @unchecked Sendable {
+    case image(displayID: CGDirectDisplayID, image: CGImage)
+    case failure(displayID: CGDirectDisplayID, error: Error)
+    case finished
+}
+
+typealias ScreenSnapshotCancellation = () -> Void
+
+protocol ScreenSnapshotProviding {
+    func prewarm()
+
+    @discardableResult
+    func capture(
+        targets: [ScreenSnapshotTarget],
+        eventHandler: @escaping (ScreenSnapshotEvent) -> Void
+    ) -> ScreenSnapshotCancellation
+}
+
+final class ScreenSnapshotProvider: ScreenSnapshotProviding {
+    static let shared = ScreenSnapshotProvider()
+
+    private let contentCache = ScreenSnapshotContentCache()
+    private let cacheEpoch = ScreenSnapshotCacheEpoch()
+
+    private init() {}
+
+    func prewarm() {
+        let contentCache = contentCache
+        let cacheEpoch = cacheEpoch.current
+        let processID = ProcessInfo.processInfo.processIdentifier
+        Task.detached(priority: .utility) {
+            do {
+                _ = try await contentCache.captureContent(
+                    requiredDisplayIDs: [],
+                    processID: processID,
+                    cacheEpoch: cacheEpoch
+                )
+            } catch {
+                NSLog("capcap: Screen snapshot prewarm failed: \(error)")
+            }
+        }
+    }
+
+    func invalidateAndPrewarm(displayIDs: Set<CGDirectDisplayID>) {
+        let contentCache = contentCache
+        let cacheEpoch = cacheEpoch.advance()
+        let processID = ProcessInfo.processInfo.processIdentifier
+        Task.detached(priority: .utility) {
+            do {
+                _ = try await contentCache.captureContent(
+                    requiredDisplayIDs: displayIDs,
+                    processID: processID,
+                    cacheEpoch: cacheEpoch
+                )
+            } catch is CancellationError {
+                return
+            } catch {
+                NSLog("capcap: Screen snapshot metadata refresh failed: \(error)")
+            }
+        }
+    }
+
+    @discardableResult
+    func capture(
+        targets: [ScreenSnapshotTarget],
+        eventHandler: @escaping (ScreenSnapshotEvent) -> Void
+    ) -> ScreenSnapshotCancellation {
+        let delivery = ScreenSnapshotEventDelivery(eventHandler: eventHandler)
+        let contentCache = contentCache
+        let requiredDisplayIDs = Set(targets.map(\.displayID))
+        let cacheEpoch = cacheEpoch.current
+        let processID = ProcessInfo.processInfo.processIdentifier
+
+        let task = Task.detached(priority: .userInitiated) {
+            guard !Task.isCancelled else { return }
+
+            do {
+                let captureContent = try await contentCache.captureContent(
+                    requiredDisplayIDs: requiredDisplayIDs,
+                    processID: processID,
+                    cacheEpoch: cacheEpoch
+                )
+                guard !Task.isCancelled else { return }
+
+                await withTaskGroup(of: ScreenSnapshotEvent.self) { group in
+                    for target in targets {
+                        group.addTask {
+                            await Self.capture(
+                                target: target,
+                                content: captureContent.content,
+                                ownApplication: captureContent.ownApplication
+                            )
+                        }
+                    }
+
+                    for await event in group {
+                        guard !Task.isCancelled else {
+                            group.cancelAll()
+                            return
+                        }
+                        delivery.send(event)
+                    }
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                for target in targets {
+                    delivery.send(.failure(displayID: target.displayID, error: error))
+                }
+            }
+
+            guard !Task.isCancelled else { return }
+            delivery.send(.finished)
+        }
+
+        return {
+            delivery.cancel()
+            task.cancel()
+        }
+    }
+
+    private static func capture(
+        target: ScreenSnapshotTarget,
+        content: SCShareableContent,
+        ownApplication: SCRunningApplication
+    ) async -> ScreenSnapshotEvent {
+        guard target.bounds.width > 0,
+              target.bounds.height > 0,
+              target.scale > 0 else {
+            return .failure(
+                displayID: target.displayID,
+                error: ScreenSnapshotProviderError.invalidTarget(displayID: target.displayID)
+            )
+        }
+
+        guard let display = content.displays.first(where: { $0.displayID == target.displayID }) else {
+            return .failure(
+                displayID: target.displayID,
+                error: ScreenSnapshotProviderError.displayNotFound(displayID: target.displayID)
+            )
+        }
+
+        let filter = SCContentFilter(
+            display: display,
+            excludingApplications: [ownApplication],
+            exceptingWindows: []
+        )
+
+        let configuration = SCStreamConfiguration()
+        configuration.width = max(Int(ceil(target.bounds.width * target.scale)), 1)
+        configuration.height = max(Int(ceil(target.bounds.height * target.scale)), 1)
+        configuration.capturesAudio = false
+        configuration.showsCursor = false
+        configuration.captureResolution = .best
+
+        do {
+            let image = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: configuration
+            )
+            return .image(displayID: target.displayID, image: image)
+        } catch {
+            return .failure(displayID: target.displayID, error: error)
+        }
+    }
+}
+
+private struct ScreenSnapshotCaptureContent: @unchecked Sendable {
+    let content: SCShareableContent
+    let ownApplication: SCRunningApplication
+}
+
+private final class ScreenSnapshotCacheEpoch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var current: Int {
+        lock.withLock { value }
+    }
+
+    func advance() -> Int {
+        lock.withLock {
+            value += 1
+            return value
+        }
+    }
+}
+
+private actor ScreenSnapshotContentCache {
+    private struct ContentLoad {
+        let id: UUID
+        let task: Task<SCShareableContent, Error>
+    }
+
+    private var cachedContent: SCShareableContent?
+    private var cachedOwnApplication: SCRunningApplication?
+    private var loading: ContentLoad?
+    private var activeEpoch = 0
+
+    func captureContent(
+        requiredDisplayIDs: Set<CGDirectDisplayID>,
+        processID: pid_t,
+        cacheEpoch: Int
+    ) async throws -> ScreenSnapshotCaptureContent {
+        synchronize(to: cacheEpoch)
+        let content = try await displayContent(
+            requiredDisplayIDs: requiredDisplayIDs,
+            cacheEpoch: cacheEpoch
+        )
+        try validate(cacheEpoch)
+        do {
+            let captureContent = try await captureContent(
+                content: content,
+                processID: processID,
+                cacheEpoch: cacheEpoch
+            )
+            try validate(cacheEpoch)
+            return captureContent
+        } catch ScreenSnapshotProviderError.applicationNotFound {
+            // On macOS 14.0-14.3, prewarming before capcap owns a window can
+            // yield content without this process. Do not permanently reuse it.
+            cachedContent = nil
+            cachedOwnApplication = nil
+            let refreshedContent = try await displayContent(
+                requiredDisplayIDs: requiredDisplayIDs,
+                cacheEpoch: cacheEpoch
+            )
+            try validate(cacheEpoch)
+            let captureContent = try await captureContent(
+                content: refreshedContent,
+                processID: processID,
+                cacheEpoch: cacheEpoch
+            )
+            try validate(cacheEpoch)
+            return captureContent
+        }
+    }
+
+    private func captureContent(
+        content: SCShareableContent,
+        processID: pid_t,
+        cacheEpoch: Int
+    ) async throws -> ScreenSnapshotCaptureContent {
+        let ownApplication = try await ownApplication(
+            processID: processID,
+            fallbackContent: content,
+            cacheEpoch: cacheEpoch
+        )
+        return ScreenSnapshotCaptureContent(
+            content: content,
+            ownApplication: ownApplication
+        )
+    }
+
+    private func displayContent(
+        requiredDisplayIDs: Set<CGDirectDisplayID>,
+        cacheEpoch: Int
+    ) async throws -> SCShareableContent {
+        try validate(cacheEpoch)
+        if let cachedContent,
+           isSuitable(
+               cachedContent,
+               requiredDisplayIDs: requiredDisplayIDs
+           ) {
+            return cachedContent
+        }
+        var content = try await loadFreshContent()
+        try validate(cacheEpoch)
+        if !isSuitable(
+            content,
+            requiredDisplayIDs: requiredDisplayIDs
+        ) {
+            cachedContent = nil
+            content = try await loadFreshContent()
+            try validate(cacheEpoch)
+        }
+        cachedContent = content
+        return content
+    }
+
+    private func ownApplication(
+        processID: pid_t,
+        fallbackContent: SCShareableContent,
+        cacheEpoch: Int
+    ) async throws -> SCRunningApplication {
+        try validate(cacheEpoch)
+        if let cachedOwnApplication,
+           cachedOwnApplication.processID == processID {
+            return cachedOwnApplication
+        }
+        if let application = fallbackContent.applications.first(where: {
+            $0.processID == processID
+        }) {
+            cachedOwnApplication = application
+            return application
+        }
+        if #available(macOS 14.4, *) {
+            let processContent = try await SCShareableContent.currentProcess
+            try validate(cacheEpoch)
+            if let application = processContent.applications.first(where: {
+                $0.processID == processID
+            }) {
+                cachedOwnApplication = application
+                return application
+            }
+        }
+        throw ScreenSnapshotProviderError.applicationNotFound(processID: processID)
+    }
+
+    private func loadFreshContent() async throws -> SCShareableContent {
+        if let loading {
+            return try await loading.task.value
+        }
+
+        let id = UUID()
+        let task = Task.detached(priority: .userInitiated) {
+            try await SCShareableContent.excludingDesktopWindows(
+                false,
+                onScreenWindowsOnly: true
+            )
+        }
+        loading = ContentLoad(id: id, task: task)
+
+        do {
+            let content = try await task.value
+            if loading?.id == id {
+                loading = nil
+            }
+            return content
+        } catch {
+            if loading?.id == id {
+                loading = nil
+            }
+            throw error
+        }
+    }
+
+    private func synchronize(to cacheEpoch: Int) {
+        guard cacheEpoch > activeEpoch else { return }
+        activeEpoch = cacheEpoch
+        cachedContent = nil
+        cachedOwnApplication = nil
+        loading?.task.cancel()
+        loading = nil
+    }
+
+    private func validate(_ cacheEpoch: Int) throws {
+        guard cacheEpoch == activeEpoch else {
+            throw CancellationError()
+        }
+    }
+
+    private func isSuitable(
+        _ content: SCShareableContent,
+        requiredDisplayIDs: Set<CGDirectDisplayID>
+    ) -> Bool {
+        let displayIDs = Set(content.displays.map(\.displayID))
+        return requiredDisplayIDs.isSubset(of: displayIDs)
+    }
+}
+
+private final class ScreenSnapshotEventDelivery: @unchecked Sendable {
+    private let lock = NSRecursiveLock()
+    private var eventHandler: ((ScreenSnapshotEvent) -> Void)?
+    private var isCancelled = false
+
+    init(eventHandler: @escaping (ScreenSnapshotEvent) -> Void) {
+        self.eventHandler = eventHandler
+    }
+
+    func send(_ event: ScreenSnapshotEvent) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isCancelled else { return }
+        eventHandler?(event)
+    }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+        isCancelled = true
+        eventHandler = nil
+    }
+}
+
+private enum ScreenSnapshotProviderError: LocalizedError {
+    case invalidTarget(displayID: CGDirectDisplayID)
+    case displayNotFound(displayID: CGDirectDisplayID)
+    case applicationNotFound(processID: pid_t)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidTarget(displayID):
+            return "Invalid screen snapshot target for display \(displayID)"
+        case let .displayNotFound(displayID):
+            return "ScreenCaptureKit display \(displayID) was not found"
+        case let .applicationNotFound(processID):
+            return "ScreenCaptureKit application \(processID) was not found"
+        }
+    }
+}

--- a/capcap/Capture/SelectionView.swift
+++ b/capcap/Capture/SelectionView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import QuartzCore
 
 protocol SelectionViewDelegate: AnyObject {
     func selectionDidStart()
@@ -21,6 +22,11 @@ extension SelectionViewDelegate {
 
 class SelectionView: NSView {
     weak var delegate: SelectionViewDelegate?
+    var onFirstDrawCompleted: (() -> Void)?
+    var onFirstFramePresented: (() -> Void)?
+    private var firstFrameDisplayLink: CADisplayLink?
+    private var didReportFirstDraw = false
+    private var didScheduleFirstFramePresentation = false
 
     // MARK: - State
 
@@ -74,6 +80,14 @@ class SelectionView: NSView {
     /// off-main-thread pre-capture path.
     func setBackgroundSnapshot(cgImage: CGImage, pointSize: NSSize) {
         backgroundSnapshot = NSImage(cgImage: cgImage, size: pointSize)
+        needsDisplay = true
+    }
+
+    func cancelFirstFramePresentationTracking() {
+        firstFrameDisplayLink?.invalidate()
+        firstFrameDisplayLink = nil
+        onFirstDrawCompleted = nil
+        onFirstFramePresented = nil
     }
 
     // MARK: - Window Detection
@@ -477,6 +491,10 @@ class SelectionView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
+        defer {
+            reportFirstDrawIfNeeded()
+            scheduleFirstFramePresentationIfNeeded()
+        }
 
         // Draw pre-captured screen snapshot as background so transient
         // menus/popups remain visible even after they dismiss.
@@ -550,6 +568,34 @@ class SelectionView: NSView {
         } else if state == .selected, let selectionSizeLabelOverride {
             SelectionView.drawSizeLabel(context: context, rect: rect, text: selectionSizeLabelOverride)
         }
+    }
+
+    private func reportFirstDrawIfNeeded() {
+        guard !didReportFirstDraw else { return }
+        didReportFirstDraw = true
+        onFirstDrawCompleted?()
+        onFirstDrawCompleted = nil
+    }
+
+    private func scheduleFirstFramePresentationIfNeeded() {
+        guard !didScheduleFirstFramePresentation else { return }
+        didScheduleFirstFramePresentation = true
+
+        // draw(_:) only proves AppKit prepared the backing store. Waiting for
+        // the next display refresh also captures the render-to-display gap.
+        let displayLink = displayLink(
+            target: self,
+            selector: #selector(firstFrameDisplayLinkDidFire(_:))
+        )
+        firstFrameDisplayLink = displayLink
+        displayLink.add(to: .main, forMode: .common)
+    }
+
+    @objc private func firstFrameDisplayLinkDidFire(_ displayLink: CADisplayLink) {
+        displayLink.invalidate()
+        firstFrameDisplayLink = nil
+        onFirstFramePresented?()
+        onFirstFramePresented = nil
     }
 
     private func drawHandles(context: CGContext, rect: NSRect) {

--- a/capcap/Capture/SelectionView.swift
+++ b/capcap/Capture/SelectionView.swift
@@ -70,6 +70,12 @@ class SelectionView: NSView {
     /// Full-screen snapshot taken before overlays appear, preserving transient menus/popups.
     var backgroundSnapshot: NSImage?
 
+    /// Seeds the frozen desktop background from a CGImage produced by the
+    /// off-main-thread pre-capture path.
+    func setBackgroundSnapshot(cgImage: CGImage, pointSize: NSSize) {
+        backgroundSnapshot = NSImage(cgImage: cgImage, size: pointSize)
+    }
+
     // MARK: - Window Detection
 
     /// Set by OverlayWindowController so the view can detect windows under the cursor.

--- a/capcap/Capture/WindowDetector.swift
+++ b/capcap/Capture/WindowDetector.swift
@@ -1,7 +1,7 @@
 import AppKit
 import CoreGraphics
 
-struct DetectedWindow {
+struct DetectedWindow: Sendable {
     let name: String
     let windowID: CGWindowID
     let layer: Int
@@ -12,24 +12,48 @@ struct DetectedWindow {
     }
 }
 
+enum WindowDetectionError: LocalizedError, Sendable {
+    case invalidPrimaryScreenArea(CGFloat)
+    case windowListUnavailable
+    case invalidWindowListPayload
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPrimaryScreenArea(let area):
+            return "Invalid primary screen area for window detection: \(area)"
+        case .windowListUnavailable:
+            return "Core Graphics did not return a window list"
+        case .invalidWindowListPayload:
+            return "Core Graphics returned an unexpected window list payload"
+        }
+    }
+}
+
 class WindowDetector {
     private var windows: [DetectedWindow] = []
-    private let ownPID = ProcessInfo.processInfo.processIdentifier
 
-    /// Snapshot all visible windows (excluding this app).
-    func refresh() {
-        guard let infoList = CGWindowListCopyWindowInfo(
-            [.optionOnScreenOnly, .excludeDesktopElements],
-            kCGNullWindowID
-        ) as? [[String: Any]] else {
-            windows = []
-            return
+    /// Build an immutable window snapshot without touching AppKit screen state
+    /// or this detector's mutable state. Safe to call from a background queue.
+    static func snapshot(
+        primaryScreenArea: CGFloat
+    ) -> Result<[DetectedWindow], WindowDetectionError> {
+        guard primaryScreenArea.isFinite, primaryScreenArea > 0 else {
+            return .failure(.invalidPrimaryScreenArea(primaryScreenArea))
         }
 
-        let primaryFrame = NSScreen.screens[0].frame
-        let screenArea = primaryFrame.width * primaryFrame.height
+        guard let rawInfoList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) else {
+            return .failure(.windowListUnavailable)
+        }
+        guard let infoList = rawInfoList as? [[String: Any]] else {
+            return .failure(.invalidWindowListPayload)
+        }
 
-        windows = infoList.compactMap { info in
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+
+        let detectedWindows: [DetectedWindow] = infoList.compactMap { info -> DetectedWindow? in
             guard let pid = info[kCGWindowOwnerPID as String] as? pid_t,
                   let boundsNS = info[kCGWindowBounds as String] as? NSDictionary,
                   let layer = info[kCGWindowLayer as String] as? Int,
@@ -58,7 +82,7 @@ class WindowDetector {
             // skip near-full-screen ones — these are typically invisible system
             // overlays (e.g. input method backgrounds) that block real windows.
             if layer >= 20 {
-                if rect.width * rect.height > screenArea * 0.8 {
+                if rect.width * rect.height > primaryScreenArea * 0.8 {
                     return nil
                 }
             }
@@ -68,6 +92,13 @@ class WindowDetector {
 
             return DetectedWindow(name: name, windowID: windowID, layer: layer, frame: rect)
         }
+
+        return .success(detectedWindows)
+    }
+
+    /// Commit a previously-created value snapshot to this detector.
+    func apply(_ detectedWindows: [DetectedWindow]) {
+        windows = detectedWindows
     }
 
     /// High-layer system surfaces (menu bar, Dock, popups) are often only a

--- a/capcap/Editor/BeautifyContainerView.swift
+++ b/capcap/Editor/BeautifyContainerView.swift
@@ -126,8 +126,11 @@ final class BeautifyContainerView: NSView {
         let outerRect = CGRect(origin: .zero, size: bounds.size)
         let innerRect = canvasView.frame
 
-        // 1. Background
-        if preset.isWallpaper, let wp = wallpaperImage {
+        // 1. Background — transparent uses a checkerboard so empty padding
+        // and rounded corners are visible; export stays pure alpha.
+        if preset.isTransparent {
+            BeautifyRenderer.drawCheckerboard(in: outerRect)
+        } else if preset.isWallpaper, let wp = wallpaperImage {
             BeautifyRenderer.drawWallpaperBackground(in: outerRect, wallpaper: wp)
         } else {
             BeautifyRenderer.drawBackground(in: outerRect, preset: preset)

--- a/capcap/Editor/BeautifyPreset.swift
+++ b/capcap/Editor/BeautifyPreset.swift
@@ -7,19 +7,41 @@ struct BeautifyPreset: Equatable {
     let endColor: NSColor
     let angleDegrees: CGFloat
     let isWallpaper: Bool
+    let isTransparent: Bool
 
-    init(id: String, displayName: String, startColor: NSColor, endColor: NSColor, angleDegrees: CGFloat, isWallpaper: Bool = false) {
+    init(
+        id: String,
+        displayName: String,
+        startColor: NSColor,
+        endColor: NSColor,
+        angleDegrees: CGFloat,
+        isWallpaper: Bool = false,
+        isTransparent: Bool = false
+    ) {
         self.id = id
         self.displayName = displayName
         self.startColor = startColor
         self.endColor = endColor
         self.angleDegrees = angleDegrees
         self.isWallpaper = isWallpaper
+        self.isTransparent = isTransparent
     }
 
     static func == (lhs: BeautifyPreset, rhs: BeautifyPreset) -> Bool {
         lhs.id == rhs.id
     }
+
+    /// Pure alpha background: export keeps transparent padding and rounded
+    /// corners; live preview draws a checkerboard so the empty areas stay
+    /// visible in the editor.
+    static let transparent = BeautifyPreset(
+        id: "transparent",
+        displayName: L10n.beautifyPresetTransparent,
+        startColor: .clear,
+        endColor: .clear,
+        angleDegrees: 0,
+        isTransparent: true
+    )
 
     static let wallpaper = BeautifyPreset(
         id: "wallpaper",
@@ -31,6 +53,7 @@ struct BeautifyPreset: Equatable {
     )
 
     static let defaults: [BeautifyPreset] = [
+        transparent,
         BeautifyPreset(
             id: "peach-blue",
             displayName: L10n.beautifyPresetPeachBlue,

--- a/capcap/Editor/BeautifyRenderer.swift
+++ b/capcap/Editor/BeautifyRenderer.swift
@@ -182,15 +182,45 @@ enum BeautifyRenderer {
     // MARK: - Drawing primitives
 
     /// Draws a linear gradient across `outerRect` using the preset colors and angle.
-    /// For wallpaper presets the area is left clear (caller draws wallpaper separately).
+    /// Wallpaper and transparent presets leave the area empty (caller draws
+    /// wallpaper / checkerboard separately for preview; export clears alpha).
     static func drawBackground(in outerRect: CGRect, preset: BeautifyPreset) {
-        if preset.isWallpaper { return }
+        if preset.isWallpaper || preset.isTransparent { return }
         guard let gradient = NSGradient(starting: preset.startColor, ending: preset.endColor) else {
             preset.startColor.setFill()
             outerRect.fill()
             return
         }
         gradient.draw(in: outerRect, angle: preset.angleDegrees)
+    }
+
+    /// Checkerboard used only in the editor preview so transparent padding
+    /// and rounded corners stay visible. Never baked into exported images.
+    static func drawCheckerboard(in rect: CGRect, square: CGFloat = 14) {
+        guard square > 0, rect.width > 0, rect.height > 0 else { return }
+        var y = rect.minY
+        var row = 0
+        while y < rect.maxY {
+            var x = rect.minX
+            var column = 0
+            while x < rect.maxX {
+                let isLight = (row + column).isMultiple(of: 2)
+                (isLight
+                    ? NSColor(calibratedWhite: 0.88, alpha: 1)
+                    : NSColor(calibratedWhite: 0.72, alpha: 1)
+                ).setFill()
+                NSRect(
+                    x: x,
+                    y: y,
+                    width: min(square, rect.maxX - x),
+                    height: min(square, rect.maxY - y)
+                ).fill()
+                x += square
+                column += 1
+            }
+            y += square
+            row += 1
+        }
     }
 
     /// Draws a wallpaper image as background, aspect-fill centered in `outerRect`.
@@ -368,8 +398,11 @@ enum BeautifyRenderer {
 
         let cg = ctx.cgContext
 
-        // 1. Background
-        if preset.isWallpaper, let wp = wallpaperImage {
+        // 1. Background — transparent presets keep pure alpha (no desktop,
+        // no wallpaper, no gradient). Checkerboard is preview-only.
+        if preset.isTransparent {
+            cg.clear(outerRect)
+        } else if preset.isWallpaper, let wp = wallpaperImage {
             drawWallpaperBackground(in: outerRect, wallpaper: wp)
         } else {
             drawBackground(in: outerRect, preset: preset)

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -253,6 +253,9 @@ class EditWindowController {
 
         showToolbar()
         updateHistoryButtons(canUndo: canvas.canUndo, canRedo: canvas.canRedo)
+        if Defaults.beautifyAutoEnabled {
+            activateBeautify()
+        }
         bringEditorToFront()
     }
 
@@ -5509,7 +5512,9 @@ private class BeautifySwatchView: NSView {
         NSGraphicsContext.saveGraphicsState()
         clipPath.addClip()
 
-        if preset.isWallpaper, let wpImage = wallpaperThumbnail {
+        if preset.isTransparent {
+            BeautifyRenderer.drawCheckerboard(in: circleRect, square: 4)
+        } else if preset.isWallpaper, let wpImage = wallpaperThumbnail {
             wpImage.draw(in: circleRect, from: .zero, operation: .sourceOver, fraction: 1.0)
         } else if preset.isWallpaper {
             // Fallback: draw a landscape-like icon

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -1665,6 +1665,32 @@ class EditWindowController {
     private func save() {
         canvasView?.commitActiveTextEditing()
         guard let finalImage = currentCompositeImage() else { return }
+        let quality = Defaults.screenshotSaveQuality
+
+        if Defaults.askSaveLocation {
+            let suggestedName = FilenameTemplate.imageFileName(
+                for: finalImage,
+                fileExtension: quality.fileExtension,
+                consumeCounters: false
+            )
+            promptForScreenshotSaveLocation(suggestedName: suggestedName) { [weak self] chosen in
+                guard let self else { return }
+                guard let chosen else {
+                    self.bringEditorToFront()
+                    return
+                }
+                self.finishSave(image: finalImage, destinationOverride: chosen)
+            }
+            return
+        }
+
+        finishSave(image: finalImage, destinationOverride: nil)
+    }
+
+    /// Encode and write the screenshot. When `destinationOverride` is set (user
+    /// picked a path in the save panel), write there; otherwise create a unique
+    /// file under the configured screenshot directory.
+    private func finishSave(image finalImage: NSImage, destinationOverride: URL?) {
         let targetScreen = screen
         let focusReturn = onRequestFocusReturn
         let quality = Defaults.screenshotSaveQuality
@@ -1687,15 +1713,24 @@ class EditWindowController {
                 ToastWindow.show(message: L10n.screenshotCompressionFailed, on: targetScreen, duration: 3.0)
             case .success(let output):
                 do {
-                    let filename = FilenameTemplate.imageFileName(
-                        for: finalImage,
-                        fileExtension: output.fileExtension,
-                        imageSize: output.pixelSize
-                    )
-                    let destination = try SaveDestination.uniqueFile(
-                        in: Defaults.screenshotSaveDirectory,
-                        fileName: filename
-                    )
+                    let destination: URL
+                    if let destinationOverride {
+                        destination = destinationOverride
+                        try FileManager.default.createDirectory(
+                            at: destination.deletingLastPathComponent(),
+                            withIntermediateDirectories: true
+                        )
+                    } else {
+                        let filename = FilenameTemplate.imageFileName(
+                            for: finalImage,
+                            fileExtension: output.fileExtension,
+                            imageSize: output.pixelSize
+                        )
+                        destination = try SaveDestination.uniqueFile(
+                            in: Defaults.screenshotSaveDirectory,
+                            fileName: filename
+                        )
+                    }
                     try output.data.write(to: destination, options: .atomic)
                     let directoryPath = SaveDestination.displayPath(destination.deletingLastPathComponent())
                     ToastWindow.show(message: L10n.screenshotSaved(to: directoryPath), on: targetScreen)
@@ -1715,6 +1750,35 @@ class EditWindowController {
             if shouldReturnFocus {
                 focusReturn?()
             }
+        }
+    }
+
+    /// Save panel for screenshots. Presented as a sheet on the overlay when
+    /// possible so it appears above the capture chrome. Cancel keeps the editor open.
+    private func promptForScreenshotSaveLocation(
+        suggestedName: String,
+        completion: @escaping (URL?) -> Void
+    ) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+        panel.directoryURL = Defaults.screenshotSaveDirectory
+        panel.nameFieldStringValue = suggestedName
+
+        let finish: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .OK, let url = panel.url else {
+                completion(nil)
+                return
+            }
+            completion(url)
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+        if let hostWindow = hostSelectionView?.window {
+            panel.beginSheetModal(for: hostWindow, completionHandler: finish)
+        } else {
+            panel.begin(completionHandler: finish)
         }
     }
 

--- a/capcap/Settings/SettingsView.swift
+++ b/capcap/Settings/SettingsView.swift
@@ -310,6 +310,9 @@ class SettingsView: NSView {
     private var screenshotQualityClipboardPopup: NSPopUpButton!
     private var savePathTitleLabel: NSTextField!
     private var savePathSubtitleLabel: NSTextField!
+    private var askSaveLocationTitleLabel: NSTextField!
+    private var askSaveLocationHintLabel: NSTextField?
+    private var askSaveLocationSwitch: NSSwitch!
     private var autoRevealSavedFilesTitleLabel: NSTextField!
     private var autoRevealSavedFilesHintLabel: NSTextField?
     private var autoRevealSavedFilesSwitch: NSSwitch!
@@ -1654,6 +1657,22 @@ class SettingsView: NSView {
         inner.addArrangedSubview(topDivider)
         topDivider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
 
+        let askSave = makeToggleRow(
+            title: L10n.askSaveLocationLabel,
+            subtitle: L10n.askSaveLocationHint,
+            isOn: Defaults.askSaveLocation,
+            action: #selector(askSaveLocationToggled(_:))
+        )
+        askSaveLocationTitleLabel = askSave.title
+        askSaveLocationHintLabel = askSave.subtitle
+        askSaveLocationSwitch = askSave.toggle
+        inner.addArrangedSubview(askSave.row)
+        askSave.row.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let askSaveDivider = rowDivider()
+        inner.addArrangedSubview(askSaveDivider)
+        askSaveDivider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
         let autoReveal = makeToggleRow(
             title: L10n.autoRevealSavedFilesLabel,
             subtitle: L10n.autoRevealSavedFilesHint,
@@ -2901,6 +2920,10 @@ class SettingsView: NSView {
     private func selectedScreenshotQuality(from sender: NSPopUpButton) -> ScreenshotImageQuality? {
         guard let raw = sender.selectedItem?.representedObject as? String else { return nil }
         return ScreenshotImageQuality(rawValue: raw)
+    }
+
+    @objc private func askSaveLocationToggled(_ sender: NSSwitch) {
+        Defaults.askSaveLocation = sender.state == .on
     }
 
     @objc private func autoRevealSavedFilesToggled(_ sender: NSSwitch) {
@@ -4883,6 +4906,9 @@ class SettingsView: NSView {
         refreshScreenshotQualityControls()
         savePathTitleLabel?.stringValue = L10n.savePathTitle
         savePathSubtitleLabel?.stringValue = L10n.savePathSubtitle
+        askSaveLocationTitleLabel?.stringValue = L10n.askSaveLocationLabel
+        askSaveLocationHintLabel?.stringValue = L10n.askSaveLocationHint
+        askSaveLocationSwitch?.state = Defaults.askSaveLocation ? .on : .off
         autoRevealSavedFilesTitleLabel?.stringValue = L10n.autoRevealSavedFilesLabel
         autoRevealSavedFilesHintLabel?.stringValue = L10n.autoRevealSavedFilesHint
         autoRevealSavedFilesSwitch?.state = Defaults.autoRevealSavedFiles ? .on : .off

--- a/capcap/Settings/SettingsView.swift
+++ b/capcap/Settings/SettingsView.swift
@@ -93,6 +93,18 @@ class SettingsView: NSView {
     private var windowShadowSizeTitleLabel: NSTextField!
     private var windowShadowSizeHintLabel: NSTextField!
 
+    // Beautify defaults card
+    private var beautifyAutoSwitch: NSSwitch!
+    private var beautifyAutoTitleLabel: NSTextField!
+    private var beautifyAutoSubtitleLabel: NSTextField?
+    private var beautifyPresetTitleLabel: NSTextField!
+    private var beautifyPaddingTitleLabel: NSTextField!
+    private var beautifyPaddingValueLabel: NSTextField!
+    private var beautifyPaddingSlider: NSSlider!
+    private var beautifyShadowSwitch: NSSwitch!
+    private var beautifyShadowTitleLabel: NSTextField!
+    private var beautifyPresetSwatches: [BeautifySettingsSwatchView] = []
+
     // Screenshot shortcut card
     private var shortcutTitleLabel: NSTextField!
     private var shortcutField: NSTextField!
@@ -720,6 +732,8 @@ class SettingsView: NSView {
 
         buildWindowShadowCard(into: stack)
 
+        buildBeautifyDefaultsCard(into: stack)
+
         buildHistoryAndCountdownCards(into: stack)
 
         let filenameCard = FilenameRuleCard()
@@ -823,6 +837,112 @@ class SettingsView: NSView {
         windowShadowSizeTitleLabel?.textColor = NSColor.white.withAlphaComponent(on ? 0.94 : 0.4)
         windowShadowSizeValueLabel?.textColor = NSColor.white.withAlphaComponent(on ? 0.88 : 0.4)
         windowShadowPreview?.isEffectEnabled = on
+    }
+
+    /// Default beautify behaviour when the annotation editor opens: optional
+    /// auto-enable plus the shared last-used preset / padding / shadow.
+    private func buildBeautifyDefaultsCard(into stack: NSStackView) {
+        let card = CardView()
+        let inner = NSStackView()
+        inner.orientation = .vertical
+        inner.alignment = .leading
+        inner.spacing = 10
+        inner.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(inner)
+        pin(inner, to: card, insets: NSEdgeInsets(top: 4, left: 14, bottom: 14, right: 14))
+
+        let toggle = makeToggleRow(
+            title: L10n.beautifyAutoToggleLabel,
+            subtitle: L10n.beautifyAutoToggleHint,
+            isOn: Defaults.beautifyAutoEnabled,
+            action: #selector(beautifyAutoToggled(_:))
+        )
+        beautifyAutoTitleLabel = toggle.title
+        beautifyAutoSubtitleLabel = toggle.subtitle
+        beautifyAutoSwitch = toggle.toggle
+        inner.addArrangedSubview(toggle.row)
+        toggle.row.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let divider = rowDivider()
+        inner.addArrangedSubview(divider)
+        divider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        beautifyPresetTitleLabel = primaryLabel(L10n.beautifyDefaultPresetLabel)
+        inner.addArrangedSubview(beautifyPresetTitleLabel)
+
+        let swatchRow = NSStackView()
+        swatchRow.orientation = .horizontal
+        swatchRow.alignment = .centerY
+        swatchRow.spacing = 8
+        swatchRow.translatesAutoresizingMaskIntoConstraints = false
+
+        let selectedID = Defaults.lastBeautifyPresetID ?? BeautifyPreset.defaultPreset.id
+        beautifyPresetSwatches = []
+        for preset in BeautifyPreset.defaults {
+            let swatch = BeautifySettingsSwatchView(preset: preset)
+            swatch.isSelected = (preset.id == selectedID)
+            swatch.target = self
+            swatch.action = #selector(beautifyPresetSwatchClicked(_:))
+            swatch.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                swatch.widthAnchor.constraint(equalToConstant: 24),
+                swatch.heightAnchor.constraint(equalToConstant: 24),
+            ])
+            if preset.isWallpaper, let screen = NSScreen.main {
+                BeautifyRenderer.loadWallpaperImage(for: screen) { [weak swatch] image in
+                    swatch?.wallpaperThumbnail = image
+                }
+            }
+            swatchRow.addArrangedSubview(swatch)
+            beautifyPresetSwatches.append(swatch)
+        }
+        inner.addArrangedSubview(swatchRow)
+
+        let paddingHeader = NSStackView()
+        paddingHeader.orientation = .horizontal
+        paddingHeader.alignment = .firstBaseline
+        paddingHeader.spacing = 8
+        paddingHeader.translatesAutoresizingMaskIntoConstraints = false
+
+        beautifyPaddingTitleLabel = primaryLabel(L10n.beautifyDefaultPaddingLabel)
+        paddingHeader.addArrangedSubview(beautifyPaddingTitleLabel)
+        paddingHeader.addArrangedSubview(flexSpacer())
+
+        beautifyPaddingValueLabel = NSTextField(labelWithString: "\(Int(Defaults.lastBeautifyPadding.rounded()))")
+        beautifyPaddingValueLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .semibold)
+        beautifyPaddingValueLabel.textColor = NSColor.white.withAlphaComponent(0.88)
+        paddingHeader.addArrangedSubview(beautifyPaddingValueLabel)
+
+        inner.addArrangedSubview(paddingHeader)
+        paddingHeader.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let paddingSlider = NSSlider(
+            value: Defaults.lastBeautifyPadding,
+            minValue: Double(BeautifyRenderer.paddingSliderMin),
+            maxValue: Double(BeautifyRenderer.paddingSliderMax),
+            target: self,
+            action: #selector(beautifyPaddingChanged(_:))
+        )
+        paddingSlider.controlSize = .small
+        paddingSlider.isContinuous = true
+        paddingSlider.translatesAutoresizingMaskIntoConstraints = false
+        beautifyPaddingSlider = paddingSlider
+        inner.addArrangedSubview(paddingSlider)
+        paddingSlider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let shadowToggle = makeToggleRow(
+            title: L10n.beautifyShadowEffect,
+            subtitle: nil,
+            isOn: Defaults.lastBeautifyShadowEnabled,
+            action: #selector(beautifyShadowToggled(_:))
+        )
+        beautifyShadowTitleLabel = shadowToggle.title
+        beautifyShadowSwitch = shadowToggle.toggle
+        inner.addArrangedSubview(shadowToggle.row)
+        shadowToggle.row.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        stack.addArrangedSubview(card)
+        card.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
     }
 
     private func updateHistoryCacheControlsEnabled() {
@@ -2928,6 +3048,26 @@ class SettingsView: NSView {
         windowShadowPreview?.shadowSize = CGFloat(Defaults.windowShadowSize)
     }
 
+    @objc private func beautifyAutoToggled(_ sender: NSSwitch) {
+        Defaults.beautifyAutoEnabled = sender.state == .on
+    }
+
+    @objc private func beautifyPresetSwatchClicked(_ sender: BeautifySettingsSwatchView) {
+        Defaults.lastBeautifyPresetID = sender.preset.id
+        for swatch in beautifyPresetSwatches {
+            swatch.isSelected = (swatch.preset.id == sender.preset.id)
+        }
+    }
+
+    @objc private func beautifyPaddingChanged(_ sender: NSSlider) {
+        Defaults.lastBeautifyPadding = sender.doubleValue
+        beautifyPaddingValueLabel?.stringValue = "\(Int(Defaults.lastBeautifyPadding.rounded()))"
+    }
+
+    @objc private func beautifyShadowToggled(_ sender: NSSwitch) {
+        Defaults.lastBeautifyShadowEnabled = sender.state == .on
+    }
+
     @objc private func launchAtLoginToggled(_ sender: NSSwitch) {
         let enable = sender.state == .on
         let ok = LaunchAtLogin.setEnabled(enable)
@@ -4775,6 +4915,20 @@ class SettingsView: NSView {
         windowShadowSubtitleLabel?.stringValue = L10n.windowShadowToggleHint
         windowShadowSizeTitleLabel?.stringValue = L10n.windowShadowSizeLabel
         windowShadowSizeHintLabel?.stringValue = L10n.windowShadowSizeHint
+        beautifyAutoTitleLabel?.stringValue = L10n.beautifyAutoToggleLabel
+        beautifyAutoSubtitleLabel?.stringValue = L10n.beautifyAutoToggleHint
+        beautifyPresetTitleLabel?.stringValue = L10n.beautifyDefaultPresetLabel
+        beautifyPaddingTitleLabel?.stringValue = L10n.beautifyDefaultPaddingLabel
+        beautifyShadowTitleLabel?.stringValue = L10n.beautifyShadowEffect
+        beautifyAutoSwitch?.state = Defaults.beautifyAutoEnabled ? .on : .off
+        beautifyPaddingSlider?.doubleValue = Defaults.lastBeautifyPadding
+        beautifyPaddingValueLabel?.stringValue = "\(Int(Defaults.lastBeautifyPadding.rounded()))"
+        beautifyShadowSwitch?.state = Defaults.lastBeautifyShadowEnabled ? .on : .off
+        let beautifySelectedID = Defaults.lastBeautifyPresetID ?? BeautifyPreset.defaultPreset.id
+        for swatch in beautifyPresetSwatches {
+            swatch.isSelected = (swatch.preset.id == beautifySelectedID)
+            swatch.needsDisplay = true
+        }
         countdownTitleLabel?.stringValue = L10n.countdownLabel
         countdownHintLabel?.stringValue = L10n.countdownHint
         countdownValueLabel?.stringValue = "\(Defaults.countdownSeconds)\(L10n.countdownSecondsSuffix)"
@@ -5418,6 +5572,83 @@ private final class SettingsTickSlider: NSControl {
         let steps = ((clamped - minValue) / stepValue).rounded()
         let snapped = minValue + steps * stepValue
         return min(max(snapped, minValue), maxValue)
+    }
+}
+
+// MARK: - Beautify settings swatch
+
+/// Compact circular preset swatch used in the general settings beautify card.
+private final class BeautifySettingsSwatchView: NSView {
+    let preset: BeautifyPreset
+    weak var target: AnyObject?
+    var action: Selector?
+
+    var isSelected: Bool = false {
+        didSet { needsDisplay = true }
+    }
+
+    var wallpaperThumbnail: NSImage? {
+        didSet { needsDisplay = true }
+    }
+
+    init(preset: BeautifyPreset) {
+        self.preset = preset
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        if let action {
+            _ = target?.perform(action, with: self)
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let inset: CGFloat = isSelected ? 1 : 2
+        let circleRect = bounds.insetBy(dx: inset, dy: inset)
+        let clipPath = NSBezierPath(ovalIn: circleRect)
+        NSGraphicsContext.saveGraphicsState()
+        clipPath.addClip()
+
+        if preset.isTransparent {
+            BeautifyRenderer.drawCheckerboard(in: circleRect, square: 4)
+        } else if preset.isWallpaper, let wpImage = wallpaperThumbnail {
+            wpImage.draw(in: circleRect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        } else if preset.isWallpaper {
+            NSColor(red: 0.4, green: 0.65, blue: 0.45, alpha: 1).setFill()
+            circleRect.fill()
+            let sky = NSRect(
+                x: circleRect.origin.x,
+                y: circleRect.midY,
+                width: circleRect.width,
+                height: circleRect.height / 2
+            )
+            NSColor(red: 0.55, green: 0.75, blue: 0.92, alpha: 1).setFill()
+            sky.fill()
+        } else if let gradient = NSGradient(starting: preset.startColor, ending: preset.endColor) {
+            gradient.draw(in: circleRect, angle: preset.angleDegrees)
+        } else {
+            preset.startColor.setFill()
+            circleRect.fill()
+        }
+        NSGraphicsContext.restoreGraphicsState()
+
+        let border = NSBezierPath(ovalIn: circleRect)
+        AdaptiveChrome.border.setStroke()
+        border.lineWidth = 0.5
+        border.stroke()
+
+        if isSelected {
+            let ring = NSBezierPath(ovalIn: bounds)
+            NSColor(calibratedRed: 0, green: 0.83, blue: 0.42, alpha: 1).setStroke()
+            ring.lineWidth = 2
+            ring.stroke()
+        }
     }
 }
 

--- a/capcap/Trigger/HotkeyManager.swift
+++ b/capcap/Trigger/HotkeyManager.swift
@@ -23,7 +23,7 @@ final class HotkeyManager {
     private var colorPickerHotKeyRef: EventHotKeyRef?
     private var historyPanelHotKeyRef: EventHotKeyRef?
     private var historyPreviewHotKeyRef: EventHotKeyRef?
-    private var callback: (() -> Void)?
+    private var callback: ((CaptureTriggerContext) -> Void)?
     private var countdownCallback: (() -> Void)?
     private var selectedImagePinCallback: (() -> Void)?
     private var clipboardImagePinCallback: (() -> Void)?
@@ -88,7 +88,7 @@ final class HotkeyManager {
 
     /// Register the saved screenshot hotkey, if any. Caller's `callback` is invoked when fired.
     /// If no hotkey is saved (key code == 0 with no function-key fallback), this no-ops.
-    func register(callback: @escaping () -> Void) {
+    func register(callback: @escaping (CaptureTriggerContext) -> Void) {
         self.callback = callback
         unregister()
 
@@ -1125,6 +1125,20 @@ final class HotkeyManager {
                 )
                 guard status == noErr else { return OSStatus(eventNotHandledErr) }
 
+                if hkID.id == HotkeyManager.regularHotKeyID {
+                    guard let callback = mgr.callback else { return noErr }
+                    let context = CaptureTriggerContext(
+                        source: .keyboardShortcut,
+                        eventUptime: GetEventTime(eventRef)
+                    )
+                    context.mark(.carbonEventReceived)
+                    MainRunLoopScheduler.perform {
+                        context.mark(.mainRunLoopCallback)
+                        callback(context)
+                    }
+                    return noErr
+                }
+
                 let callback: (() -> Void)?
                 switch hkID.id {
                 case HotkeyManager.countdownHotKeyID:
@@ -1157,8 +1171,6 @@ final class HotkeyManager {
                     callback = mgr.historyPanelCallback
                 case HotkeyManager.historyPreviewHotKeyID:
                     callback = mgr.historyPreviewCallback
-                case HotkeyManager.regularHotKeyID:
-                    callback = mgr.callback
                 default:
                     callback = nil
                 }

--- a/capcap/Trigger/KeyMonitor.swift
+++ b/capcap/Trigger/KeyMonitor.swift
@@ -22,10 +22,17 @@ class KeyMonitor {
     private var lastCommandPressOption: Bool = false
     private var commandIsDown = false
     private var otherKeyPressed = false
-    private let onTrigger: () -> Void
+    private let onTrigger: (CaptureTriggerContext) -> Void
     private let onCountdownTrigger: () -> Void
 
-    init(onTrigger: @escaping () -> Void,
+    private struct ModifierSample {
+        let commandIsDown: Bool
+        let optionIsDown: Bool
+        let hasDisruptiveModifiers: Bool
+        let eventUptime: TimeInterval
+    }
+
+    init(onTrigger: @escaping (CaptureTriggerContext) -> Void,
          onCountdownTrigger: @escaping () -> Void) {
         self.onTrigger = onTrigger
         self.onCountdownTrigger = onCountdownTrigger
@@ -81,12 +88,13 @@ class KeyMonitor {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        handleFlagsChanged(
+        handleModifierSample(ModifierSample(
             commandIsDown: event.modifierFlags.contains(.command),
             optionIsDown: event.modifierFlags.contains(.option),
             hasDisruptiveModifiers: event.modifierFlags.contains(.shift)
-                || event.modifierFlags.contains(.control)
-        )
+                || event.modifierFlags.contains(.control),
+            eventUptime: event.timestamp
+        ))
     }
 
     @discardableResult
@@ -128,53 +136,62 @@ class KeyMonitor {
             otherKeyPressed = true
         case .flagsChanged:
             let flags = event.flags
-            handleFlagsChanged(
+            handleModifierSample(ModifierSample(
                 commandIsDown: flags.contains(.maskCommand),
                 optionIsDown: flags.contains(.maskAlternate),
                 hasDisruptiveModifiers: flags.contains(.maskShift)
-                    || flags.contains(.maskControl)
-            )
+                    || flags.contains(.maskControl),
+                eventUptime: Double(event.timestamp) / 1_000_000_000
+            ))
         default:
             break
         }
     }
 
-    private func handleFlagsChanged(
-        commandIsDown cmd: Bool,
-        optionIsDown opt: Bool,
-        hasDisruptiveModifiers hasDisruptive: Bool
-    ) {
+    private func handleModifierSample(_ sample: ModifierSample) {
         guard isEnabled else { return }
 
-        if hasDisruptive {
+        if sample.hasDisruptiveModifiers {
             otherKeyPressed = true
-            commandIsDown = cmd
+            commandIsDown = sample.commandIsDown
             return
         }
 
-        if cmd && !commandIsDown {
-            let now = ProcessInfo.processInfo.systemUptime
+        if sample.commandIsDown && !commandIsDown {
+            let now = sample.eventUptime
             let withinWindow = (now - lastCommandPressTime) < Defaults.doubleTapInterval
             // Both presses must share the same Option state — a sequence that
             // mixes ⌘ then ⌥⌘ is treated as a fresh first press, not a double-tap.
             let isDoubleTap = !otherKeyPressed
                 && withinWindow
-                && lastCommandPressOption == opt
+                && lastCommandPressOption == sample.optionIsDown
 
             if isDoubleTap {
-                if opt {
+                if sample.optionIsDown {
                     MainRunLoopScheduler.perform { [weak self] in self?.onCountdownTrigger() }
                 } else if isRegularDoubleTapEnabled {
-                    MainRunLoopScheduler.perform { [weak self] in self?.onTrigger() }
+                    let context = CaptureTriggerContext(
+                        source: .doubleCommand,
+                        eventUptime: now
+                    )
+                    context.mark(.doubleCommandDetected)
+                    MainRunLoopScheduler.perform { [weak self] in
+                        context.mark(.mainRunLoopCallback)
+                        guard let self else {
+                            context.finish(.ignored)
+                            return
+                        }
+                        self.onTrigger(context)
+                    }
                 }
                 lastCommandPressTime = 0
             } else {
                 lastCommandPressTime = now
-                lastCommandPressOption = opt
+                lastCommandPressOption = sample.optionIsDown
             }
             otherKeyPressed = false
         }
 
-        commandIsDown = cmd
+        commandIsDown = sample.commandIsDown
     }
 }

--- a/capcap/Utilities/AppPermissions.swift
+++ b/capcap/Utilities/AppPermissions.swift
@@ -10,27 +10,6 @@ enum AppPermissions {
     }
 
     static var screenRecordingGranted: Bool {
-        if #available(macOS 15.0, *) {
-            return CGPreflightScreenCaptureAccess()
-        } else {
-            guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
-                return false
-            }
-            let myPID = ProcessInfo.processInfo.processIdentifier
-            let foreignWindow = windowList.first { info in
-                guard let pid = info[kCGWindowOwnerPID as String] as? Int32 else { return false }
-                return pid != myPID
-            }
-            guard let windowID = foreignWindow?[kCGWindowNumber as String] as? CGWindowID else {
-                return true
-            }
-            let image = CGWindowListCreateImage(
-                CGRect(x: 0, y: 0, width: 1, height: 1),
-                .optionIncludingWindow,
-                windowID,
-                [.boundsIgnoreFraming]
-            )
-            return image != nil
-        }
+        CGPreflightScreenCaptureAccess()
     }
 }

--- a/capcap/Utilities/CaptureLatencyTrace.swift
+++ b/capcap/Utilities/CaptureLatencyTrace.swift
@@ -1,0 +1,194 @@
+import Foundation
+import os.signpost
+
+/// Carries one screenshot trigger's identity and monotonic event timestamp
+/// across callback, run-loop, capture preparation, and overlay presentation.
+struct CaptureTriggerContext: @unchecked Sendable {
+    enum Source: String, Sendable {
+        case keyboardShortcut = "keyboard-shortcut"
+        case doubleCommand = "double-command"
+        case menu
+        case countdown
+        case programmatic
+    }
+
+    let sessionID: UUID
+    let source: Source
+    let eventUptime: TimeInterval
+    let trace: CaptureLatencyTrace
+
+    init(
+        source: Source,
+        eventUptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) {
+        let sessionID = UUID()
+        self.sessionID = sessionID
+        self.source = source
+        self.eventUptime = eventUptime
+        self.trace = CaptureLatencyTrace(
+            sessionID: sessionID,
+            source: source,
+            eventUptime: eventUptime
+        )
+    }
+
+    func mark(_ stage: CaptureLatencyTrace.Stage) {
+        trace.mark(stage)
+    }
+
+    func finish(_ outcome: CaptureLatencyTrace.Outcome) {
+        trace.finish(outcome)
+    }
+}
+
+/// Low-overhead signpost trace for the user-visible screenshot startup path.
+/// DiagnosticLog is intentionally touched only after `finish`, on a dedicated
+/// background queue, so synchronous file I/O can never delay the first frame.
+final class CaptureLatencyTrace: @unchecked Sendable {
+    enum Stage: String, Sendable {
+        case carbonEventReceived = "carbon-event-received"
+        case doubleCommandDetected = "double-command-detected"
+        case mainRunLoopCallback = "main-run-loop-callback"
+        case handleTrigger = "handle-trigger"
+        case startCapture = "start-capture"
+        case overlayInitialized = "overlay-initialized"
+        case activateRequested = "activate-requested"
+        case backgroundPreparationStarted = "background-preparation-started"
+        case windowEnumerationReady = "window-enumeration-ready"
+        case windowEnumerationApplied = "window-enumeration-applied"
+        case snapshotCaptureStarted = "snapshot-capture-started"
+        case snapshotResultReady = "snapshot-result-ready"
+        case snapshotResultApplied = "snapshot-result-applied"
+        case overlayOrderedFront = "overlay-ordered-front"
+        case firstDrawCompleted = "first-draw-completed"
+        case firstFrame = "first-frame"
+    }
+
+    enum Outcome: String, Sendable {
+        case presented
+        case cancelled
+        case superseded
+        case failed
+        case ignored
+        case rerouted
+    }
+
+    private struct StageSample {
+        let stage: Stage
+        let uptime: TimeInterval
+        let thread: String
+    }
+
+    private static let signpostLog = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.capcap.capture",
+        category: "CaptureLatency"
+    )
+    private static let diagnosticQueue = DispatchQueue(
+        label: "com.capcap.capture-latency-log",
+        qos: .utility
+    )
+
+    let sessionID: UUID
+    let source: CaptureTriggerContext.Source
+    let eventUptime: TimeInterval
+
+    private let signpostID: OSSignpostID
+    private let lock = NSLock()
+    private var samples: [StageSample] = []
+    private var isFinished = false
+
+    init(
+        sessionID: UUID,
+        source: CaptureTriggerContext.Source,
+        eventUptime: TimeInterval
+    ) {
+        self.sessionID = sessionID
+        self.source = source
+        self.eventUptime = eventUptime
+        self.signpostID = OSSignpostID(log: Self.signpostLog)
+
+        os_signpost(
+            .begin,
+            log: Self.signpostLog,
+            name: "CaptureTrigger",
+            signpostID: signpostID,
+            "session=%{public}@ source=%{public}@ eventUptime=%.6f",
+            sessionID.uuidString,
+            source.rawValue,
+            eventUptime
+        )
+    }
+
+    func mark(_ stage: Stage) {
+        let now = ProcessInfo.processInfo.systemUptime
+        let elapsedMs = max(0, now - eventUptime) * 1_000
+
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        samples.append(
+            StageSample(
+                stage: stage,
+                uptime: now,
+                thread: Thread.isMainThread ? "main" : "background"
+            )
+        )
+        os_signpost(
+            .event,
+            log: Self.signpostLog,
+            name: "CaptureStage",
+            signpostID: signpostID,
+            "session=%{public}@ source=%{public}@ stage=%{public}@ elapsedMs=%.1f",
+            sessionID.uuidString,
+            source.rawValue,
+            stage.rawValue,
+            elapsedMs
+        )
+        lock.unlock()
+    }
+
+    func finish(_ outcome: Outcome) {
+        let finishedUptime = ProcessInfo.processInfo.systemUptime
+
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        let completedSamples = samples
+        lock.unlock()
+
+        let totalMs = max(0, finishedUptime - eventUptime) * 1_000
+        os_signpost(
+            .end,
+            log: Self.signpostLog,
+            name: "CaptureTrigger",
+            signpostID: signpostID,
+            "session=%{public}@ source=%{public}@ outcome=%{public}@ totalMs=%.1f",
+            sessionID.uuidString,
+            source.rawValue,
+            outcome.rawValue,
+            totalMs
+        )
+
+        let stageSummary = completedSamples.map { sample in
+            let elapsedMs = max(0, sample.uptime - eventUptime) * 1_000
+            return "\(sample.stage.rawValue)=\(String(format: "%.1f", elapsedMs))@\(sample.thread)"
+        }.joined(separator: ",")
+        let metadata: [String: Any] = [
+            "session": sessionID.uuidString,
+            "source": source.rawValue,
+            "eventUptime": String(format: "%.6f", eventUptime),
+            "outcome": outcome.rawValue,
+            "totalMs": String(format: "%.1f", totalMs),
+            "stages": stageSummary,
+        ]
+
+        Self.diagnosticQueue.async {
+            DiagnosticLog.log("capture-latency", "trace-finished", metadata: metadata)
+        }
+    }
+}

--- a/capcap/Utilities/Defaults.swift
+++ b/capcap/Utilities/Defaults.swift
@@ -373,6 +373,7 @@ enum L10n {
 
     // Beautify
     static var beautify: String { s("beautify") }
+    static var beautifyPresetTransparent: String { s("beautifyPresetTransparent") }
     static var beautifyPresetPeachBlue: String { s("beautifyPresetPeachBlue") }
     static var beautifyPresetMintTeal: String { s("beautifyPresetMintTeal") }
     static var beautifyPresetPeachPink: String { s("beautifyPresetPeachPink") }
@@ -383,6 +384,10 @@ enum L10n {
     static var beautifyPresetNeutralGray: String { s("beautifyPresetNeutralGray") }
     static var beautifyPresetWallpaper: String { s("beautifyPresetWallpaper") }
     static var beautifyShadowEffect: String { s("beautifyShadowEffect") }
+    static var beautifyAutoToggleLabel: String { s("beautifyAutoToggleLabel") }
+    static var beautifyAutoToggleHint: String { s("beautifyAutoToggleHint") }
+    static var beautifyDefaultPresetLabel: String { s("beautifyDefaultPresetLabel") }
+    static var beautifyDefaultPaddingLabel: String { s("beautifyDefaultPaddingLabel") }
 
     // Text tool
     static var textStrokeEffect: String { s("textStrokeEffect") }
@@ -1656,6 +1661,20 @@ struct Defaults {
         }
         set {
             defaults.set(newValue, forKey: "lastBeautifyShadowEnabled")
+        }
+    }
+
+    /// When true, the annotation editor opens with beautify already active,
+    /// using the last-used preset / padding / shadow settings.
+    static var beautifyAutoEnabled: Bool {
+        get {
+            if defaults.object(forKey: "beautifyAutoEnabled") == nil {
+                return false
+            }
+            return defaults.bool(forKey: "beautifyAutoEnabled")
+        }
+        set {
+            defaults.set(newValue, forKey: "beautifyAutoEnabled")
         }
     }
 

--- a/capcap/Utilities/Defaults.swift
+++ b/capcap/Utilities/Defaults.swift
@@ -115,6 +115,8 @@ enum L10n {
     static var windowShadowSizeHint: String { s("windowShadowSizeHint") }
     static var savePathTitle: String { s("savePathTitle") }
     static var savePathSubtitle: String { s("savePathSubtitle") }
+    static var askSaveLocationLabel: String { s("askSaveLocationLabel") }
+    static var askSaveLocationHint: String { s("askSaveLocationHint") }
     static var autoRevealSavedFilesLabel: String { s("autoRevealSavedFilesLabel") }
     static var autoRevealSavedFilesHint: String { s("autoRevealSavedFilesHint") }
     static var recordingSavePathLabel: String { s("recordingSavePathLabel") }
@@ -1128,6 +1130,20 @@ struct Defaults {
         }
         set {
             defaults.set(newValue.rawValue, forKey: "recordingSavePreference")
+        }
+    }
+
+    /// When true (default), screenshot "Save to file" shows a save panel.
+    /// When false, screenshots write straight to `screenshotSaveDirectory`.
+    static var askSaveLocation: Bool {
+        get {
+            if defaults.object(forKey: "askSaveLocation") == nil {
+                return true
+            }
+            return defaults.bool(forKey: "askSaveLocation")
+        }
+        set {
+            defaults.set(newValue, forKey: "askSaveLocation")
         }
     }
 


### PR DESCRIPTION
## Summary

- 消除截图选区 overlay 启动卡顿，并补充预热、面板复用、快照与延迟诊断能力
- 将全屏预截图移到后台并行执行，支持准备阶段按 Esc 取消
- 新增透明美化背景预设，并支持在设置中配置默认美化、预设、边距与阴影
- 保存截图时默认询问位置，取消保存后保留编辑会话，并允许在设置中恢复直接保存

## Test plan

- [ ] 使用快捷键连续截图，确认选区及时出现且无转圈卡顿
- [ ] 在截图准备阶段按 Esc，确认能够取消
- [ ] 选择透明美化背景并导出，确认背景保留 alpha
- [ ] 修改默认美化设置，确认新编辑会话按配置生效
- [ ] 默认保存时确认弹出位置选择，取消后编辑器仍保留
- [ ] 关闭询问保存位置后，确认截图直接保存到配置目录

Supersedes #122, #123, and #124