### PR TITLE
feat: add modifier selection dragging and menu bar component targeting

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "Countdown Seconds";
 "countdownHint" = "Hold ⌥ Option then double-tap ⌘ or press the screenshot shortcut to start a countdown before capture, Esc cancels";
 "countdownSecondsSuffix" = "s";
+"selectionMoveModifierToggleLabel" = "Hold Modifier to Move Selection";
+"selectionMoveModifierToggleHint" = "Hold the selected modifier and drag anywhere inside the screenshot selection";
+"selectionMoveModifierLabel" = "Modifier";
+"selectionMoveModifierCommand" = "⌘ Command";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Control";
+"selectionMoveModifierShift" = "⇧ Shift";
 "windowShadowToggleLabel" = "Window Capture Shadow";
 "windowShadowToggleHint" = "Round the corners of window captures and add a macOS-style drop shadow";
 "windowShadowSizeLabel" = "Shadow Size";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "Secondes du compte à rebours";
 "countdownHint" = "Maintenez ⌥ Option puis double-appuyez sur ⌘ ou utilisez le raccourci de capture pour lancer un compte à rebours avant la capture, Échap pour annuler";
 "countdownSecondsSuffix" = "s";
+"selectionMoveModifierToggleLabel" = "Déplacer la sélection avec une touche de modification";
+"selectionMoveModifierToggleHint" = "Maintenez la touche choisie et faites glisser n’importe où dans la sélection";
+"selectionMoveModifierLabel" = "Touche de modification";
+"selectionMoveModifierCommand" = "⌘ Commande";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Contrôle";
+"selectionMoveModifierShift" = "⇧ Majuscule";
 "windowShadowToggleLabel" = "Ombre des captures de fenêtre";
 "windowShadowToggleHint" = "Arrondit les coins des captures de fenêtre et ajoute une ombre portée façon macOS";
 "windowShadowSizeLabel" = "Taille de l'ombre";

--- a/Resources/ja.lproj/Localizable.strings
+++ b/Resources/ja.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "カウントダウン秒数";
 "countdownHint" = "⌥ Option を押しながら ⌘ をダブルタップするか、スクリーンショットのショートカットを押すと、撮影前にカウントダウンが始まります。Esc でキャンセル";
 "countdownSecondsSuffix" = "秒";
+"selectionMoveModifierToggleLabel" = "修飾キーで選択範囲を移動";
+"selectionMoveModifierToggleHint" = "選択した修飾キーを押しながら、スクリーンショットの選択範囲内をドラッグ";
+"selectionMoveModifierLabel" = "修飾キー";
+"selectionMoveModifierCommand" = "⌘ Command";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Control";
+"selectionMoveModifierShift" = "⇧ Shift";
 "windowShadowToggleLabel" = "ウインドウ撮影の影";
 "windowShadowToggleHint" = "ウインドウを選んで撮影すると角を丸め、macOS 風のドロップシャドウを追加します";
 "windowShadowSizeLabel" = "影のサイズ";

--- a/Resources/ko.lproj/Localizable.strings
+++ b/Resources/ko.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "카운트다운 초";
 "countdownHint" = "⌥ Option 을 누른 채 ⌘ 를 두 번 누르거나 스크린샷 단축키를 누르면 캡처 전에 카운트다운이 시작되며 Esc 로 취소";
 "countdownSecondsSuffix" = "초";
+"selectionMoveModifierToggleLabel" = "보조 키로 선택 영역 이동";
+"selectionMoveModifierToggleHint" = "선택한 보조 키를 누른 채 스크린샷 선택 영역 안을 드래그";
+"selectionMoveModifierLabel" = "보조 키";
+"selectionMoveModifierCommand" = "⌘ Command";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Control";
+"selectionMoveModifierShift" = "⇧ Shift";
 "windowShadowToggleLabel" = "창 캡처 그림자";
 "windowShadowToggleHint" = "창을 선택해 캡처할 때 모서리를 둥글게 하고 macOS 스타일 그림자를 추가합니다";
 "windowShadowSizeLabel" = "그림자 크기";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "Секунды обратного отсчёта";
 "countdownHint" = "Удерживайте ⌥ Option, затем дважды нажмите ⌘ или сочетание для снимка, чтобы запустить обратный отсчёт перед захватом, Esc — отмена";
 "countdownSecondsSuffix" = "с";
+"selectionMoveModifierToggleLabel" = "Перемещение области с клавишей-модификатором";
+"selectionMoveModifierToggleHint" = "Удерживайте выбранную клавишу и перетаскивайте область из любой точки внутри неё";
+"selectionMoveModifierLabel" = "Клавиша-модификатор";
+"selectionMoveModifierCommand" = "⌘ Command";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Control";
+"selectionMoveModifierShift" = "⇧ Shift";
 "windowShadowToggleLabel" = "Тень при снимке окна";
 "windowShadowToggleHint" = "Скругляет углы снимков окон и добавляет тень в стиле macOS";
 "windowShadowSizeLabel" = "Размер тени";

--- a/Resources/vi.lproj/Localizable.strings
+++ b/Resources/vi.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "Số giây đếm ngược";
 "countdownHint" = "Giữ ⌥ Option rồi nhấn đúp ⌘ hoặc nhấn phím tắt chụp màn hình để bắt đầu đếm ngược trước khi chụp, Esc để hủy";
 "countdownSecondsSuffix" = "giây";
+"selectionMoveModifierToggleLabel" = "Di chuyển vùng chọn bằng phím bổ trợ";
+"selectionMoveModifierToggleHint" = "Giữ phím đã chọn rồi kéo từ bất kỳ vị trí nào trong vùng chụp";
+"selectionMoveModifierLabel" = "Phím bổ trợ";
+"selectionMoveModifierCommand" = "⌘ Command";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Control";
+"selectionMoveModifierShift" = "⇧ Shift";
 "windowShadowToggleLabel" = "Đổ bóng khi chụp cửa sổ";
 "windowShadowToggleHint" = "Bo góc ảnh chụp cửa sổ và thêm bóng đổ kiểu macOS";
 "windowShadowSizeLabel" = "Kích thước bóng";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "倒计时秒数";
 "countdownHint" = "按住 ⌥ Option 后双击 ⌘ 或按截图快捷键，先弹出倒计时再截图，按 Esc 取消";
 "countdownSecondsSuffix" = "秒";
+"selectionMoveModifierToggleLabel" = "按住修饰键移动选区";
+"selectionMoveModifierToggleHint" = "按住所选修饰键，可从截图选区内任意位置拖动";
+"selectionMoveModifierLabel" = "修饰键";
+"selectionMoveModifierCommand" = "⌘ Command";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Control";
+"selectionMoveModifierShift" = "⇧ Shift";
 "windowShadowToggleLabel" = "窗口截图阴影";
 "windowShadowToggleHint" = "点选窗口截图时自动裁出圆角，并加上 macOS 风格的投影";
 "windowShadowSizeLabel" = "阴影大小";

--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -31,6 +31,13 @@
 "countdownLabel" = "倒數秒數";
 "countdownHint" = "按住 ⌥ Option 後連按兩下 ⌘，或按下截圖快捷鍵，即可先倒數再截圖，按 Esc 取消";
 "countdownSecondsSuffix" = "秒";
+"selectionMoveModifierToggleLabel" = "按住修飾鍵移動選取範圍";
+"selectionMoveModifierToggleHint" = "按住所選修飾鍵，可從截圖選取範圍內任意位置拖動";
+"selectionMoveModifierLabel" = "修飾鍵";
+"selectionMoveModifierCommand" = "⌘ Command";
+"selectionMoveModifierOption" = "⌥ Option";
+"selectionMoveModifierControl" = "⌃ Control";
+"selectionMoveModifierShift" = "⇧ Shift";
 "windowShadowToggleLabel" = "視窗截圖陰影";
 "windowShadowToggleHint" = "擷取視窗時裁出圓角，並加上 macOS 風格的陰影";
 "windowShadowSizeLabel" = "陰影大小";

--- a/Tests/capcapTests/OverlayPresentationTests.swift
+++ b/Tests/capcapTests/OverlayPresentationTests.swift
@@ -484,6 +484,51 @@ final class OverlayPresentationTests: XCTestCase {
         XCTAssertTrue(controller.isCaptureSessionEnded)
     }
 
+    func testMenuBarComponentUsesSnapshotWithoutWindowCaptureEffects() throws {
+        _ = NSApplication.shared
+        let provider = ControlledScreenSnapshotProvider()
+        let statusWindowID: CGWindowID = 84
+        let controller = OverlayWindowController(
+            snapshotProvider: provider,
+            windowSnapshotLoader: { _ in
+                .success([
+                    DetectedWindow(
+                        name: "Control Center",
+                        windowID: statusWindowID,
+                        layer: Int(CGWindowLevelForKey(.statusWindow)),
+                        frame: CGRect(x: 100, y: 0, width: 90, height: 30),
+                        target: .menuBarComponent
+                    )
+                ])
+            },
+            windowImageLoader: { _, _ in
+                try await Task.sleep(for: .seconds(2))
+                return nil
+            },
+            onComplete: { _ in }
+        )
+        controller.activate()
+        defer { controller.cancel() }
+        drainMainRunLoop()
+
+        let selectionView = try XCTUnwrap(controller.activeSelectionViews.first)
+        let displayID = try XCTUnwrap(provider.targets.first?.displayID)
+        provider.emit(.image(displayID: displayID, image: makeImage(width: 100, height: 100)))
+        drainMainRunLoop()
+
+        controller.selectionDidComplete(
+            rect: selectionRect(in: selectionView),
+            inView: selectionView,
+            isWindowSelection: true,
+            windowID: statusWindowID
+        )
+
+        XCTAssertFalse(controller.isWaitingForWindowCapture)
+        XCTAssertTrue(controller.hasActiveEditor)
+        XCTAssertTrue(controller.activeEditorHasWindowBaseImage)
+        XCTAssertFalse(controller.activeEditorUsesWindowEffects)
+    }
+
     func testSurfaceIsWarmOnlyAfterPresentedFrame() throws {
         _ = NSApplication.shared
         let screen = try XCTUnwrap(NSScreen.screens.first)
@@ -520,13 +565,13 @@ final class OverlayPresentationTests: XCTestCase {
         )
     }
 
-    private func makeImage() -> CGImage {
+    private func makeImage(width: Int = 1, height: Int = 1) -> CGImage {
         let context = CGContext(
             data: nil,
-            width: 1,
-            height: 1,
+            width: width,
+            height: height,
             bitsPerComponent: 8,
-            bytesPerRow: 4,
+            bytesPerRow: width * 4,
             space: CGColorSpaceCreateDeviceRGB(),
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         )!

--- a/Tests/capcapTests/SelectionMoveModifierTests.swift
+++ b/Tests/capcapTests/SelectionMoveModifierTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import XCTest
+@testable import capcap
+
+final class SelectionMoveModifierTests: XCTestCase {
+    private let enabledKey = "selectionMoveModifierEnabled"
+    private let modifierKey = "selectionMoveModifier"
+    private var previousEnabledValue: Any?
+    private var previousModifierValue: Any?
+
+    override func setUp() {
+        super.setUp()
+        previousEnabledValue = UserDefaults.standard.object(forKey: enabledKey)
+        previousModifierValue = UserDefaults.standard.object(forKey: modifierKey)
+        UserDefaults.standard.removeObject(forKey: enabledKey)
+        UserDefaults.standard.removeObject(forKey: modifierKey)
+    }
+
+    override func tearDown() {
+        restore(previousEnabledValue, forKey: enabledKey)
+        restore(previousModifierValue, forKey: modifierKey)
+        super.tearDown()
+    }
+
+    func testDefaultsToEnabledCommandModifier() {
+        XCTAssertTrue(Defaults.selectionMoveModifierEnabled)
+        XCTAssertEqual(Defaults.selectionMoveModifier, .command)
+    }
+
+    func testInvalidStoredModifierNormalizesToCommand() {
+        UserDefaults.standard.set("capsLock", forKey: modifierKey)
+
+        XCTAssertEqual(Defaults.selectionMoveModifier, .command)
+    }
+
+    func testAllModifiersMatchWithOrWithoutExtraModifiers() {
+        for modifier in SelectionMoveModifier.allCases {
+            Defaults.selectionMoveModifier = modifier
+            let expectedFlag = flag(for: modifier)
+
+            XCTAssertTrue(Defaults.matchesSelectionMoveModifier(expectedFlag))
+            XCTAssertTrue(Defaults.matchesSelectionMoveModifier([expectedFlag, .capsLock]))
+        }
+    }
+
+    func testDisabledSettingNeverMatches() {
+        Defaults.selectionMoveModifier = .command
+        Defaults.selectionMoveModifierEnabled = false
+
+        XCTAssertFalse(Defaults.matchesSelectionMoveModifier(.command))
+    }
+
+    private func flag(for modifier: SelectionMoveModifier) -> NSEvent.ModifierFlags {
+        switch modifier {
+        case .command: return .command
+        case .option: return .option
+        case .control: return .control
+        case .shift: return .shift
+        }
+    }
+
+    private func restore(_ value: Any?, forKey key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+}

--- a/Tests/capcapTests/SelectionViewModifierMoveTests.swift
+++ b/Tests/capcapTests/SelectionViewModifierMoveTests.swift
@@ -1,0 +1,175 @@
+import AppKit
+import XCTest
+@testable import capcap
+
+@MainActor
+final class SelectionViewModifierMoveTests: XCTestCase {
+    private let enabledKey = "selectionMoveModifierEnabled"
+    private let modifierKey = "selectionMoveModifier"
+    private var previousEnabledValue: Any?
+    private var previousModifierValue: Any?
+
+    override func setUp() {
+        super.setUp()
+        _ = NSApplication.shared
+        previousEnabledValue = UserDefaults.standard.object(forKey: enabledKey)
+        previousModifierValue = UserDefaults.standard.object(forKey: modifierKey)
+        Defaults.selectionMoveModifierEnabled = true
+        Defaults.selectionMoveModifier = .command
+    }
+
+    override func tearDown() {
+        restore(previousEnabledValue, forKey: enabledKey)
+        restore(previousModifierValue, forKey: modifierKey)
+        super.tearDown()
+    }
+
+    func testNoModifierLeavesEditorSelectionUnchanged() throws {
+        let fixture = makeFixture()
+
+        try drag(fixture.view, from: NSPoint(x: 80, y: 80), to: NSPoint(x: 110, y: 100))
+
+        XCTAssertEqual(fixture.view.currentSelectionRect, fixture.initialRect)
+        XCTAssertEqual(fixture.delegate.changeCount, 0)
+    }
+
+    func testCommandMovesSelectionAndContinuesAfterModifierRelease() throws {
+        let fixture = makeFixture()
+
+        try drag(
+            fixture.view,
+            from: NSPoint(x: 80, y: 80),
+            to: NSPoint(x: 110, y: 100),
+            downFlags: .command,
+            dragFlags: []
+        )
+
+        XCTAssertEqual(
+            fixture.view.currentSelectionRect,
+            fixture.initialRect.offsetBy(dx: 30, dy: 20)
+        )
+        XCTAssertEqual(fixture.delegate.changeCount, 1)
+        XCTAssertEqual(fixture.delegate.completionCount, 1)
+    }
+
+    func testOptionConfigurationRejectsCommandAndAcceptsOption() throws {
+        Defaults.selectionMoveModifier = .option
+        let fixture = makeFixture()
+
+        try drag(
+            fixture.view,
+            from: NSPoint(x: 80, y: 80),
+            to: NSPoint(x: 100, y: 90),
+            downFlags: .command
+        )
+        XCTAssertEqual(fixture.view.currentSelectionRect, fixture.initialRect)
+
+        try drag(
+            fixture.view,
+            from: NSPoint(x: 80, y: 80),
+            to: NSPoint(x: 100, y: 90),
+            downFlags: .option
+        )
+        XCTAssertEqual(
+            fixture.view.currentSelectionRect,
+            fixture.initialRect.offsetBy(dx: 20, dy: 10)
+        )
+    }
+
+    func testModifierMoveClampsSelectionToScreenBounds() throws {
+        let fixture = makeFixture()
+
+        try drag(
+            fixture.view,
+            from: NSPoint(x: 80, y: 80),
+            to: NSPoint(x: 500, y: 500),
+            downFlags: .command
+        )
+
+        XCTAssertEqual(
+            fixture.view.currentSelectionRect,
+            NSRect(x: 200, y: 160, width: 100, height: 80)
+        )
+    }
+
+    private func makeFixture() -> (view: SelectionView, delegate: SelectionDelegateSpy, initialRect: NSRect) {
+        let view = SelectionView(frame: NSRect(x: 0, y: 0, width: 300, height: 240))
+        let window = NSWindow(
+            contentRect: view.bounds,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = view
+        let initialRect = NSRect(x: 50, y: 50, width: 100, height: 80)
+        let delegate = SelectionDelegateSpy()
+        view.delegate = delegate
+        view.updateSelectionRect(initialRect)
+        view.annotationToolActive = true
+        view.selectionLocked = true
+        view.selectionInteractionEnabled = true
+        return (view, delegate, initialRect)
+    }
+
+    private func drag(
+        _ view: SelectionView,
+        from start: NSPoint,
+        to end: NSPoint,
+        downFlags: NSEvent.ModifierFlags = [],
+        dragFlags: NSEvent.ModifierFlags? = nil
+    ) throws {
+        view.mouseDown(with: try mouseEvent(type: .leftMouseDown, point: start, flags: downFlags))
+        view.mouseDragged(with: try mouseEvent(
+            type: .leftMouseDragged,
+            point: end,
+            flags: dragFlags ?? downFlags
+        ))
+        view.mouseUp(with: try mouseEvent(type: .leftMouseUp, point: end, flags: dragFlags ?? downFlags))
+    }
+
+    private func mouseEvent(
+        type: NSEvent.EventType,
+        point: NSPoint,
+        flags: NSEvent.ModifierFlags
+    ) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.mouseEvent(
+            with: type,
+            location: point,
+            modifierFlags: flags,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+
+    private func restore(_ value: Any?, forKey key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+}
+
+private final class SelectionDelegateSpy: SelectionViewDelegate {
+    private(set) var changeCount = 0
+    private(set) var completionCount = 0
+
+    func selectionDidStart() {}
+
+    func selectionDidComplete(
+        rect: NSRect,
+        inView view: NSView,
+        isWindowSelection: Bool,
+        windowID: CGWindowID?
+    ) {
+        completionCount += 1
+    }
+
+    func selectionDidChange(rect: NSRect, inView view: NSView) {
+        changeCount += 1
+    }
+}

--- a/Tests/capcapTests/WindowDetectorTests.swift
+++ b/Tests/capcapTests/WindowDetectorTests.swift
@@ -3,39 +3,98 @@ import XCTest
 @testable import capcap
 
 final class WindowDetectorTests: XCTestCase {
-    func testWindowAtIgnoresTransientSurfacesAboveAppWindows() {
+    private let primaryDisplay = CGRect(x: 0, y: 0, width: 1728, height: 1117)
+    private let secondaryDisplay = CGRect(x: 1728, y: -220, width: 1440, height: 900)
+    private var statusLayer: Int { Int(CGWindowLevelForKey(.statusWindow)) }
+
+    func testLayerZeroWindowRemainsSelectable() {
+        XCTAssertEqual(
+            WindowDetector.targetType(
+                layer: 0,
+                frame: CGRect(x: 80, y: 100, width: 800, height: 600),
+                displayBounds: [primaryDisplay]
+            ),
+            .applicationWindow
+        )
+    }
+
+    func testTopAlignedStatusWindowIsMenuBarComponentOnPrimaryDisplay() {
+        XCTAssertEqual(
+            WindowDetector.targetType(
+                layer: statusLayer,
+                frame: CGRect(x: 1410, y: 0, width: 90, height: 30),
+                displayBounds: [primaryDisplay]
+            ),
+            .menuBarComponent
+        )
+    }
+
+    func testTopAlignedStatusWindowIsMenuBarComponentOnSecondaryDisplay() {
+        XCTAssertEqual(
+            WindowDetector.targetType(
+                layer: statusLayer,
+                frame: CGRect(x: 2860, y: -220, width: 120, height: 30),
+                displayBounds: [primaryDisplay, secondaryDisplay]
+            ),
+            .menuBarComponent
+        )
+    }
+
+    func testStatusWindowAwayFromDisplayTopIsRejected() {
+        XCTAssertNil(WindowDetector.targetType(
+            layer: statusLayer,
+            frame: CGRect(x: 1410, y: 12, width: 90, height: 30),
+            displayBounds: [primaryDisplay]
+        ))
+    }
+
+    func testOverHeightStatusWindowIsRejected() {
+        XCTAssertNil(WindowDetector.targetType(
+            layer: statusLayer,
+            frame: CGRect(x: 1410, y: 0, width: 90, height: 65),
+            displayBounds: [primaryDisplay]
+        ))
+    }
+
+    func testWholeMenuBarIsRejected() {
+        XCTAssertNil(WindowDetector.targetType(
+            layer: statusLayer,
+            frame: CGRect(x: 0, y: 0, width: primaryDisplay.width, height: 30),
+            displayBounds: [primaryDisplay]
+        ))
+    }
+
+    func testNonStatusHighLayerSurfaceIsRejected() {
+        XCTAssertNil(WindowDetector.targetType(
+            layer: statusLayer + 1,
+            frame: CGRect(x: 1410, y: 0, width: 90, height: 30),
+            displayBounds: [primaryDisplay]
+        ))
+    }
+
+    func testWindowAtReturnsTopmostMenuBarComponentBeforeAppWindow() {
         let detector = WindowDetector()
         detector.apply([
             DetectedWindow(
-                name: "Cursor",
+                name: "Control Center",
                 windowID: 100,
-                layer: 101,
-                frame: CGRect(x: 80, y: 90, width: 36, height: 51)
+                layer: statusLayer,
+                frame: CGRect(x: 1410, y: 0, width: 90, height: 30),
+                target: .menuBarComponent
             ),
             DetectedWindow(
                 name: "Editor",
                 windowID: 200,
                 layer: 0,
-                frame: CGRect(x: 0, y: 0, width: 600, height: 400)
+                frame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+                target: .applicationWindow
             )
         ])
 
-        let detected = detector.windowAt(cgPoint: CGPoint(x: 90, y: 100))
+        let detected = detector.windowAt(cgPoint: CGPoint(x: 1440, y: 15))
 
-        XCTAssertEqual(detected?.windowID, 200)
-    }
-
-    func testWindowAtDoesNotReturnOnlyTransientSurface() {
-        let detector = WindowDetector()
-        detector.apply([
-            DetectedWindow(
-                name: "Insertion Point",
-                windowID: 300,
-                layer: 25,
-                frame: CGRect(x: 80, y: 90, width: 36, height: 51)
-            )
-        ])
-
-        XCTAssertNil(detector.windowAt(cgPoint: CGPoint(x: 90, y: 100)))
+        XCTAssertEqual(detected?.windowID, 100)
+        XCTAssertTrue(detector.usesCompositedScreenBackdrop(forWindowID: 100))
+        XCTAssertFalse(detector.usesCompositedScreenBackdrop(forWindowID: 200))
     }
 }

--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -670,6 +670,7 @@ class OverlayWindowController {
             }
         }
         magnifierLensPanelFlagsChangedLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.editController?.handleSelectionMoveModifierFlagsChanged(event)
             self?.handleMagnifierLensPanelShiftFlagsChanged(event)
             return event
         }
@@ -678,6 +679,7 @@ class OverlayWindowController {
         // Shift and legacy ⌘+C handling with global monitors so they still fire
         // when the user has Gemini (or any other app) focused underneath.
         magnifierLensPanelFlagsChangedGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.editController?.handleSelectionMoveModifierFlagsChanged(event)
             self?.handleMagnifierLensPanelShiftFlagsChanged(event)
         }
         magnifierLensPanelKeyDownGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
@@ -1305,6 +1307,7 @@ class OverlayWindowController {
 
 extension OverlayWindowController: SelectionViewDelegate {
     func selectionDidStart() {
+        editController?.prepareForSelectionGeometryChange()
         chipWindow?.dismiss()
         chipWindow = nil
         // If the lens was dismissed by a previous selection completion

--- a/capcap/Capture/OverlayWindowController.swift
+++ b/capcap/Capture/OverlayWindowController.swift
@@ -1,7 +1,7 @@
 import AppKit
 import QuartzCore
 
-typealias WindowSnapshotLoader = @Sendable (CGFloat) -> Result<[DetectedWindow], WindowDetectionError>
+typealias WindowSnapshotLoader = @Sendable (WindowDetectionContext) -> Result<[DetectedWindow], WindowDetectionError>
 typealias WindowImageLoader = @Sendable (CGWindowID, NSSize) async throws -> NSImage?
 
 struct CaptureResult {
@@ -224,7 +224,7 @@ class OverlayWindowController {
         triggerContext: CaptureTriggerContext = CaptureTriggerContext(source: .programmatic),
         snapshotProvider: ScreenSnapshotProviding = ScreenSnapshotProvider.shared,
         windowSnapshotLoader: @escaping WindowSnapshotLoader = {
-            WindowDetector.snapshot(primaryScreenArea: $0)
+            WindowDetector.snapshot(context: $0)
         },
         windowImageLoader: @escaping WindowImageLoader = { windowID, pointSize in
             try await ScreenCapturer.captureWindowAsync(
@@ -277,7 +277,7 @@ class OverlayWindowController {
         self.postCaptureAction = .edit
         self.triggerContext = nil
         self.snapshotProvider = ScreenSnapshotProvider.shared
-        self.windowSnapshotLoader = { WindowDetector.snapshot(primaryScreenArea: $0) }
+        self.windowSnapshotLoader = { WindowDetector.snapshot(context: $0) }
         self.windowImageLoader = { windowID, pointSize in
             try await ScreenCapturer.captureWindowAsync(
                 windowID: windowID,
@@ -311,7 +311,7 @@ class OverlayWindowController {
         self.postCaptureAction = .edit
         self.triggerContext = nil
         self.snapshotProvider = ScreenSnapshotProvider.shared
-        self.windowSnapshotLoader = { WindowDetector.snapshot(primaryScreenArea: $0) }
+        self.windowSnapshotLoader = { WindowDetector.snapshot(context: $0) }
         self.windowImageLoader = { windowID, pointSize in
             try await ScreenCapturer.captureWindowAsync(
                 windowID: windowID,
@@ -360,6 +360,8 @@ class OverlayWindowController {
     var isWaitingForWindowCapture: Bool { pendingWindowCapture != nil }
     var appliedSnapshotCount: Int { screenSnapshots.count }
     var hasActiveEditor: Bool { editController != nil }
+    var activeEditorUsesWindowEffects: Bool { editController?.isWindowCapture == true }
+    var activeEditorHasWindowBaseImage: Bool { activeEditorContext?.windowBaseImage != nil }
     var isCaptureSessionEnded: Bool { sessionEnded }
 
     private func beginOverlaySession() {
@@ -381,7 +383,10 @@ class OverlayWindowController {
             && eventTrackingStateProvider()
         triggerContext?.mark(.backgroundPreparationStarted)
 
-        startWindowEnumeration(generation: generation)
+        startWindowEnumeration(
+            generation: generation,
+            displayBounds: targets.map(\.bounds)
+        )
         startSnapshotCapture(targets: targets, generation: generation)
         if !waitsForEventTrackingSnapshot {
             presentOverlay(generation: generation)
@@ -424,16 +429,23 @@ class OverlayWindowController {
         return true
     }
 
-    private func startWindowEnumeration(generation: Int) {
+    private func startWindowEnumeration(
+        generation: Int,
+        displayBounds: [CGRect]
+    ) {
         guard presetImage == nil,
               suspendedDraft == nil,
               let primaryFrame = NSScreen.screens.first?.frame else { return }
         let primaryScreenArea = primaryFrame.width * primaryFrame.height
+        let detectionContext = WindowDetectionContext(
+            primaryScreenArea: primaryScreenArea,
+            displayBounds: displayBounds
+        )
 
         let snapshotLoader = windowSnapshotLoader
         let context = triggerContext
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let result = snapshotLoader(primaryScreenArea)
+            let result = snapshotLoader(detectionContext)
             context?.mark(.windowEnumerationReady)
             MainRunLoopScheduler.perform {
                 guard let self,
@@ -1428,7 +1440,7 @@ extension OverlayWindowController: SelectionViewDelegate {
         preSnapshot: CGImage?
     ) {
         guard !sessionEnded else { return }
-        if let windowID = directWindowCaptureID(for: request, preSnapshot: preSnapshot) {
+        if let windowID = directWindowCaptureID(for: request) {
             startWindowCapture(
                 windowID: windowID,
                 request: request,
@@ -1440,12 +1452,10 @@ extension OverlayWindowController: SelectionViewDelegate {
     }
 
     private func directWindowCaptureID(
-        for request: PendingSelection,
-        preSnapshot: CGImage?
+        for request: PendingSelection
     ) -> CGWindowID? {
         guard request.isWindowSelection, let windowID = request.windowID else { return nil }
-        if preSnapshot != nil,
-           windowDetector.usesCompositedScreenBackdrop(forWindowID: windowID) {
+        if windowDetector.usesCompositedScreenBackdrop(forWindowID: windowID) {
             return nil
         }
         return windowID
@@ -1522,14 +1532,20 @@ extension OverlayWindowController: SelectionViewDelegate {
         preSnapshot: CGImage?,
         directWindowImage: NSImage?
     ) {
+        let usesCompositedScreenBackdrop = request.windowID.map {
+            windowDetector.usesCompositedScreenBackdrop(forWindowID: $0)
+        } ?? false
         let windowBaseImage = imageForWindowSelection(
             isWindowSelection: request.isWindowSelection,
+            usesCompositedScreenBackdrop: usesCompositedScreenBackdrop,
             captureRect: request.captureRect,
             screen: request.screen,
             preSnapshot: preSnapshot,
             directWindowImage: directWindowImage
         )
-        let shouldApplyWindowEffects = request.isWindowSelection && windowBaseImage != nil
+        let shouldApplyWindowEffects = request.isWindowSelection
+            && !usesCompositedScreenBackdrop
+            && windowBaseImage != nil
 
         switch postCaptureAction {
         case .edit:
@@ -1907,12 +1923,20 @@ extension OverlayWindowController: SelectionViewDelegate {
 
     private func imageForWindowSelection(
         isWindowSelection: Bool,
+        usesCompositedScreenBackdrop: Bool,
         captureRect: CGRect,
         screen: NSScreen,
         preSnapshot: CGImage?,
         directWindowImage: NSImage?
     ) -> NSImage? {
         guard isWindowSelection else { return nil }
+        if usesCompositedScreenBackdrop {
+            return preSnapshotImage(
+                captureRect: captureRect,
+                screen: screen,
+                preSnapshot: preSnapshot
+            )
+        }
         let usableDirectImage = directWindowImage.flatMap { image in
             ScreenCapturer.isEffectivelyTransparent(image) ? nil : image
         }

--- a/capcap/Capture/SelectionView.swift
+++ b/capcap/Capture/SelectionView.swift
@@ -54,9 +54,14 @@ class SelectionView: NSView {
     private var selectionRect: NSRect?
     private var dragStart: NSPoint = .zero
     private var dragOriginalRect: NSRect = .zero
+    private var modifierMoveDragActive = false
 
     // Whether annotation tools are active (pass mouse events through to canvas)
     var annotationToolActive = false
+
+    /// Lets the editor restore its tool-specific cursor after a modifier move
+    /// ends or the configured modifier is released.
+    var onSelectionMoveCursorRestoreRequested: (() -> Void)?
 
     // When true, clicking outside selection won't start a new selection
     var selectionLocked = false
@@ -122,6 +127,13 @@ class SelectionView: NSView {
     // MARK: - Public
 
     var currentSelectionRect: NSRect? { selectionRect }
+    var isModifierSelectionMoveDragging: Bool { modifierMoveDragActive }
+
+    func allowsSelectionMoveModifier(_ flags: NSEvent.ModifierFlags) -> Bool {
+        selectionInteractionEnabled
+            && annotationToolActive
+            && Defaults.matchesSelectionMoveModifier(flags)
+    }
 
     func refreshHoverAtCurrentMouseLocation() {
         guard state == .idle, !selectionLocked else { return }
@@ -199,11 +211,46 @@ class SelectionView: NSView {
         window?.invalidateCursorRects(for: self)
     }
 
+    /// Updates the cursor for the configured modifier-move gesture. Returns
+    /// true when this view currently owns the cursor presentation.
+    @discardableResult
+    func refreshSelectionMoveModifierCursor(
+        flags: NSEvent.ModifierFlags = NSEvent.modifierFlags
+    ) -> Bool {
+        if modifierMoveDragActive {
+            NSCursor.closedHand.set()
+            return true
+        }
+        guard allowsSelectionMoveModifier(flags),
+              let rect = selectionRect,
+              let window
+        else { return false }
+
+        let mouseInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let point = convert(mouseInWindow, from: nil)
+        guard rect.contains(point) else { return false }
+        NSCursor.openHand.set()
+        return true
+    }
+
     // MARK: - Mouse Events
 
     override func mouseDown(with event: NSEvent) {
-        NSCursor.crosshair.set()
+        modifierMoveDragActive = false
         let point = convert(event.locationInWindow, from: nil)
+        if let rect = selectionRect,
+           state == .selected,
+           shouldBeginModifierMove(event: event, point: point, rect: rect) {
+            modifierMoveDragActive = true
+            dragAction = .move
+            dragStart = point
+            dragOriginalRect = rect
+            NSCursor.closedHand.set()
+            delegate?.selectionDidStart()
+            return
+        }
+
+        NSCursor.crosshair.set()
         if shouldConfirmFromSelectionDoubleClick(event: event, point: point) {
             dragAction = .none
             delegate?.selectionDidDoubleClickInsideSelection(inView: self)
@@ -275,6 +322,12 @@ class SelectionView: NSView {
         needsDisplay = true
     }
 
+    private func shouldBeginModifierMove(event: NSEvent, point: NSPoint, rect: NSRect) -> Bool {
+        event.buttonNumber == 0
+            && rect.contains(point)
+            && allowsSelectionMoveModifier(event.modifierFlags)
+    }
+
     private func shouldSuspendFromMaskDoubleClick(event: NSEvent, point: NSPoint) -> Bool {
         guard event.clickCount >= 2,
               state == .selected,
@@ -296,7 +349,11 @@ class SelectionView: NSView {
 
     override func mouseDragged(with event: NSEvent) {
         guard selectionInteractionEnabled else { return }
-        NSCursor.crosshair.set()
+        if modifierMoveDragActive {
+            NSCursor.closedHand.set()
+        } else {
+            NSCursor.crosshair.set()
+        }
         let point = convert(event.locationInWindow, from: nil)
 
         switch dragAction {
@@ -353,6 +410,8 @@ class SelectionView: NSView {
         NSCursor.arrow.set()
         guard selectionInteractionEnabled else {
             dragAction = .none
+            modifierMoveDragActive = false
+            restoreCursorAfterModifierMove(flags: event.modifierFlags)
             return
         }
 
@@ -392,10 +451,23 @@ class SelectionView: NSView {
         }
 
         dragAction = .none
+        modifierMoveDragActive = false
+        restoreCursorAfterModifierMove(flags: event.modifierFlags)
+    }
+
+    private func restoreCursorAfterModifierMove(flags: NSEvent.ModifierFlags) {
+        if !refreshSelectionMoveModifierCursor(flags: flags) {
+            onSelectionMoveCursorRestoreRequested?()
+        }
     }
 
     override func mouseMoved(with event: NSEvent) {
         guard selectionInteractionEnabled else { return }
+
+        if state == .selected,
+           refreshSelectionMoveModifierCursor(flags: event.modifierFlags) {
+            return
+        }
 
         // In idle state, detect windows under cursor for hover highlight
         if state == .idle && !selectionLocked {

--- a/capcap/Capture/WindowDetector.swift
+++ b/capcap/Capture/WindowDetector.swift
@@ -1,21 +1,25 @@
 import AppKit
 import CoreGraphics
 
+enum DetectedWindowTarget: Equatable, Sendable {
+    case applicationWindow
+    case menuBarComponent
+}
+
+struct WindowDetectionContext: Sendable {
+    let primaryScreenArea: CGFloat
+    let displayBounds: [CGRect]
+}
+
 struct DetectedWindow: Sendable {
     let name: String
     let windowID: CGWindowID
     let layer: Int
     let frame: CGRect   // CG coordinates (global, top-left origin)
+    let target: DetectedWindowTarget
 
     var usesCompositedScreenBackdrop: Bool {
-        layer >= 20
-    }
-
-    var isSelectableCaptureTarget: Bool {
-        // Core Graphics exposes cursor, insertion-point, menu, popup, and
-        // other transient surfaces as windows. The idle hover selection should
-        // only target normal app/desktop windows.
-        layer == 0
+        target == .menuBarComponent
     }
 }
 
@@ -42,10 +46,10 @@ class WindowDetector {
     /// Build an immutable window snapshot without touching AppKit screen state
     /// or this detector's mutable state. Safe to call from a background queue.
     static func snapshot(
-        primaryScreenArea: CGFloat
+        context: WindowDetectionContext
     ) -> Result<[DetectedWindow], WindowDetectionError> {
-        guard primaryScreenArea.isFinite, primaryScreenArea > 0 else {
-            return .failure(.invalidPrimaryScreenArea(primaryScreenArea))
+        guard context.primaryScreenArea.isFinite, context.primaryScreenArea > 0 else {
+            return .failure(.invalidPrimaryScreenArea(context.primaryScreenArea))
         }
 
         guard let rawInfoList = CGWindowListCopyWindowInfo(
@@ -84,25 +88,55 @@ class WindowDetector {
             var rect = CGRect.zero
             guard CGRectMakeWithDictionaryRepresentation(boundsNS as CFDictionary, &rect) else { return nil }
             guard rect.width > 1, rect.height > 1 else { return nil }
-
-            // For windows above normal app levels (dock, menu bar, popups, etc.),
-            // skip near-full-screen ones — these are typically invisible system
-            // overlays (e.g. input method backgrounds) that block real windows.
-            if layer >= 20 {
-                if rect.width * rect.height > primaryScreenArea * 0.8 {
-                    return nil
-                }
-            }
+            guard let target = targetType(
+                layer: layer,
+                frame: rect,
+                displayBounds: context.displayBounds
+            ) else { return nil }
 
             let name = info[kCGWindowOwnerName as String] as? String ?? ""
             let windowID = info[kCGWindowNumber as String] as? CGWindowID ?? 0
-            let detected = DetectedWindow(name: name, windowID: windowID, layer: layer, frame: rect)
-
-            guard detected.isSelectableCaptureTarget else { return nil }
-            return detected
+            return DetectedWindow(
+                name: name,
+                windowID: windowID,
+                layer: layer,
+                frame: rect,
+                target: target
+            )
         }
 
         return .success(detectedWindows)
+    }
+
+    /// Classifies only stable capture targets. Layer-0 app windows remain
+    /// selectable. At the status-window level, accept a single short window
+    /// aligned to the top of one display, while rejecting full menu bars and
+    /// other high-layer transient surfaces.
+    static func targetType(
+        layer: Int,
+        frame: CGRect,
+        displayBounds: [CGRect]
+    ) -> DetectedWindowTarget? {
+        if layer == 0 {
+            return .applicationWindow
+        }
+        guard layer == Int(CGWindowLevelForKey(.statusWindow)),
+              frame.width > 1,
+              frame.height > 1,
+              frame.height <= 64
+        else { return nil }
+
+        let owningDisplay = displayBounds.first { display in
+            guard display.width > 1, display.height > 1 else { return false }
+            let isTopAligned = abs(frame.minY - display.minY) <= 1
+            let isFullyContained = frame.minX >= display.minX
+                && frame.maxX <= display.maxX
+                && frame.minY >= display.minY
+                && frame.maxY <= display.maxY
+            let isIndividualComponent = frame.width < display.width * 0.8
+            return isTopAligned && isFullyContained && isIndividualComponent
+        }
+        return owningDisplay == nil ? nil : .menuBarComponent
     }
 
     /// Commit a previously-created value snapshot to this detector.
@@ -122,8 +156,6 @@ class WindowDetector {
     func windowAt(cgPoint: CGPoint) -> DetectedWindow? {
         // CGWindowListCopyWindowInfo returns windows in front-to-back z-order,
         // so the first hit is the topmost window.
-        return windows.first {
-            $0.isSelectableCaptureTarget && $0.frame.contains(cgPoint)
-        }
+        windows.first { $0.frame.contains(cgPoint) }
     }
 }

--- a/capcap/Editor/EditCanvasView.swift
+++ b/capcap/Editor/EditCanvasView.swift
@@ -29,6 +29,9 @@ class EditCanvasView: NSView {
     var overrideBaseImage: NSImage?
     /// Exact clicked-window image, including the WindowServer alpha mask.
     var windowBaseImage: NSImage?
+    /// True while the host selection's configured move modifier is held and
+    /// the pointer is eligible to move the whole selection.
+    var shouldUseSelectionMoveCursor: (() -> Bool)?
     var activeTool: EditTool = .none {
         didSet {
             if oldValue == .text, activeTool != .text {
@@ -3587,6 +3590,10 @@ class EditCanvasView: NSView {
     }
 
     private func updateCursor(at point: NSPoint) {
+        if shouldUseSelectionMoveCursor?() == true {
+            NSCursor.openHand.set()
+            return
+        }
         // Don't fight the text field's I-beam while editing.
         if activeTextField != nil { return }
         if activeTool == .eraser {
@@ -3640,7 +3647,7 @@ class EditCanvasView: NSView {
     /// Convert the global mouse location into view coords and refresh the
     /// cursor. Used after operations that change what's draggable (undo,
     /// commit, tool change) so the cursor doesn't lie until the next move.
-    private func refreshCursorAtCurrentLocation() {
+    func refreshCursorAtCurrentLocation() {
         guard let window else { return }
         let mouseInScreen = NSEvent.mouseLocation
         let mouseInWindow = window.convertPoint(fromScreen: mouseInScreen)

--- a/capcap/Editor/EditWindowController.swift
+++ b/capcap/Editor/EditWindowController.swift
@@ -205,6 +205,9 @@ class EditWindowController {
         scrollView.autohidesScrollers = true
         scrollView.scrollerStyle = .overlay
         scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.shouldPassThroughForSelectionMove = { [weak hostSelectionView] in
+            hostSelectionView?.allowsSelectionMoveModifier(NSEvent.modifierFlags) == true
+        }
 
         let canvas = EditCanvasView(frame: NSRect(origin: .zero, size: canvasSize))
         canvas.captureRect = captureRect
@@ -213,6 +216,16 @@ class EditWindowController {
         canvas.overrideBaseImage = overrideBaseImage
         canvas.windowBaseImage = windowBaseImage
         canvas.autoresizingMask = []
+        canvas.shouldUseSelectionMoveCursor = { [weak hostSelectionView] in
+            guard let selectionView = hostSelectionView,
+                  selectionView.allowsSelectionMoveModifier(NSEvent.modifierFlags),
+                  let window = selectionView.window,
+                  let rect = selectionView.currentSelectionRect
+            else { return false }
+            let mouseInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+            let point = selectionView.convert(mouseInWindow, from: nil)
+            return rect.contains(point)
+        }
         canvas.onAnnotationSelected = { [weak self] annotation in
             self?.handleAnnotationSelectionChanged(annotation)
         }
@@ -248,8 +261,14 @@ class EditWindowController {
         let overlay = SelectionChromeOverlay(frame: hostSelectionView.bounds)
         overlay.autoresizingMask = [.width, .height]
         overlay.selectionView = hostSelectionView
+        overlay.shouldPassThroughForSelectionMove = { [weak hostSelectionView] in
+            hostSelectionView?.allowsSelectionMoveModifier(NSEvent.modifierFlags) == true
+        }
         hostSelectionView.addSubview(overlay)
         self.selectionChromeOverlay = overlay
+        hostSelectionView.onSelectionMoveCursorRestoreRequested = { [weak self] in
+            self?.restoreEditorCursorAtCurrentLocation()
+        }
 
         showToolbar()
         updateHistoryButtons(canUndo: canvas.canUndo, canRedo: canvas.canRedo)
@@ -977,8 +996,50 @@ class EditWindowController {
     private var moveSelectionStartRect: NSRect = .zero
 
     private func handleMoveSelectionStart() {
-        canvasView?.commitActiveTextEditing()
+        prepareForSelectionGeometryChange()
         moveSelectionStartRect = hostSelectionView?.currentSelectionRect ?? .zero
+    }
+
+    func prepareForSelectionGeometryChange() {
+        canvasView?.commitActiveTextEditing()
+    }
+
+    func handleSelectionMoveModifierFlagsChanged(_ event: NSEvent) {
+        guard let selectionView = hostSelectionView,
+              let window = selectionView.window
+        else { return }
+
+        if selectionView.isModifierSelectionMoveDragging {
+            selectionView.refreshSelectionMoveModifierCursor(flags: event.modifierFlags)
+            return
+        }
+
+        let mouseInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let point = selectionView.convert(mouseInWindow, from: nil)
+        if selectionView.hitTest(point) === selectionView,
+           selectionView.refreshSelectionMoveModifierCursor(flags: event.modifierFlags) {
+            return
+        }
+        restoreEditorCursorAtCurrentLocation()
+    }
+
+    private func restoreEditorCursorAtCurrentLocation() {
+        guard let selectionView = hostSelectionView,
+              let window = selectionView.window
+        else { return }
+        let mouseInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let point = selectionView.convert(mouseInWindow, from: nil)
+        let hitView = selectionView.hitTest(point)
+
+        if hitView === selectionChromeOverlay {
+            selectionChromeOverlay?.refreshCursorAtCurrentLocation()
+        } else if let canvasView,
+                  hitView === canvasView || hitView?.isDescendant(of: canvasView) == true {
+            canvasView.refreshCursorAtCurrentLocation()
+        } else if hitView === selectionView {
+            NSCursor.arrow.set()
+            selectionView.refreshCursorRects()
+        }
     }
 
     private func handleMoveSelectionDrag(delta: CGSize) {
@@ -2154,6 +2215,11 @@ class EditWindowController {
     func handleCanvasConfirmDoubleClick(_ event: NSEvent) -> Bool {
         guard let canvasView, let hostSelectionView else { return false }
 
+        if hostSelectionView.allowsSelectionMoveModifier(event.modifierFlags) {
+            canvasView.discardPotentialConfirmDoubleClick()
+            return false
+        }
+
         guard !isScrollCaptureBusy,
               !isCropping,
               hostSelectionView.selectionLocked,
@@ -2329,10 +2395,14 @@ class EditWindowController {
         scrollCaptureHintWindow?.dismiss()
         scrollCaptureHintWindow = nil
         hostSelectionView?.window?.ignoresMouseEvents = false
+        hostSelectionView?.onSelectionMoveCursorRestoreRequested = nil
+        canvasScrollView?.shouldPassThroughForSelectionMove = nil
         canvasScrollView?.removeFromSuperview()
         canvasScrollView = nil
         canvasView?.discardPotentialConfirmDoubleClick()
+        canvasView?.shouldUseSelectionMoveCursor = nil
         canvasView = nil
+        selectionChromeOverlay?.shouldPassThroughForSelectionMove = nil
         selectionChromeOverlay?.removeFromSuperview()
         selectionChromeOverlay = nil
         hostSelectionView?.annotationToolActive = false
@@ -2696,6 +2766,7 @@ private final class ClosureMenuItem: NSMenuItem {
 
 private final class EditorScrollView: NSScrollView {
     weak var editorCanvasView: EditCanvasView?
+    var shouldPassThroughForSelectionMove: (() -> Bool)?
     /// When `true`, every viewport click is captured (drawing tools, long
     /// screenshot preview, beautify chrome). When `false` the scroll view
     /// only forwards clicks that the canvas itself claimed, so empty
@@ -2704,6 +2775,9 @@ private final class EditorScrollView: NSScrollView {
     var isInteractionEnabled = false
 
     override func hitTest(_ point: NSPoint) -> NSView? {
+        if shouldPassThroughForSelectionMove?() == true {
+            return nil
+        }
         let result = super.hitTest(point)
         if isInteractionEnabled {
             return result
@@ -5771,6 +5845,7 @@ private class BeautifySwatchView: NSView {
 /// reuses the existing resize → relayout pipeline.
 final class SelectionChromeOverlay: NSView {
     weak var selectionView: SelectionView?
+    var shouldPassThroughForSelectionMove: (() -> Bool)?
 
     private(set) var selectionRectInView: NSRect = .zero
     private(set) var isActiveAndVisible: Bool = false
@@ -5798,6 +5873,9 @@ final class SelectionChromeOverlay: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard isActiveAndVisible else { return nil }
+        if shouldPassThroughForSelectionMove?() == true {
+            return nil
+        }
         // `point` is in the superview's coordinate space.
         let local = convert(point, from: superview)
         guard SelectionView.hitTestHandle(
@@ -5840,8 +5918,28 @@ final class SelectionChromeOverlay: NSView {
 
     override func mouseMoved(with event: NSEvent) {
         guard isActiveAndVisible else { return }
+        if shouldPassThroughForSelectionMove?() == true {
+            NSCursor.openHand.set()
+            return
+        }
         let point = convert(event.locationInWindow, from: nil)
         if let handle = SelectionView.hitTestHandle(
+            point: point,
+            rect: selectionRectInView,
+            hitSize: handleHitSize
+        ) {
+            SelectionView.setCursorForHandle(handle)
+        }
+    }
+
+    func refreshCursorAtCurrentLocation() {
+        guard isActiveAndVisible, let window else { return }
+        let mouseInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let point = convert(mouseInWindow, from: nil)
+        if shouldPassThroughForSelectionMove?() == true,
+           selectionRectInView.contains(point) {
+            NSCursor.openHand.set()
+        } else if let handle = SelectionView.hitTestHandle(
             point: point,
             rect: selectionRectInView,
             hitSize: handleHitSize

--- a/capcap/Settings/SettingsView.swift
+++ b/capcap/Settings/SettingsView.swift
@@ -67,6 +67,13 @@ class SettingsView: NSView {
     private var demoModeSwitch: NSSwitch!
     private var pinAcrossSpacesSwitch: NSSwitch!
 
+    // Modifier-assisted selection movement
+    private var selectionMoveModifierSwitch: NSSwitch!
+    private var selectionMoveModifierPopup: NSPopUpButton!
+    private var selectionMoveModifierTitleLabel: NSTextField!
+    private var selectionMoveModifierHintLabel: NSTextField?
+    private var selectionMoveModifierPickerLabel: NSTextField!
+
     // Picker & slider
     private var langPicker: NSPopUpButton!
     private var historyCacheSwitch: NSSwitch!
@@ -760,6 +767,8 @@ class SettingsView: NSView {
         stack.addArrangedSubview(togglesCard)
         togglesCard.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
 
+        buildSelectionMoveModifierCard(into: stack)
+
         buildWindowShadowCard(into: stack)
 
         buildBeautifyDefaultsCard(into: stack)
@@ -776,6 +785,75 @@ class SettingsView: NSView {
         buildSavePathCard(into: stack)
 
         return wrapPane(stack)
+    }
+
+    private func buildSelectionMoveModifierCard(into stack: NSStackView) {
+        let card = CardView()
+        let inner = verticalInnerStack()
+        card.addSubview(inner)
+        pin(inner, to: card, insets: NSEdgeInsets(top: 6, left: 14, bottom: 6, right: 14))
+
+        let toggle = makeToggleRow(
+            title: L10n.selectionMoveModifierToggleLabel,
+            subtitle: L10n.selectionMoveModifierToggleHint,
+            isOn: Defaults.selectionMoveModifierEnabled,
+            action: #selector(selectionMoveModifierToggled(_:))
+        )
+        selectionMoveModifierTitleLabel = toggle.title
+        selectionMoveModifierHintLabel = toggle.subtitle
+        selectionMoveModifierSwitch = toggle.toggle
+        inner.addArrangedSubview(toggle.row)
+        toggle.row.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let divider = rowDivider()
+        inner.addArrangedSubview(divider)
+        divider.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        let pickerRow = NSStackView()
+        pickerRow.orientation = .horizontal
+        pickerRow.alignment = .centerY
+        pickerRow.spacing = 10
+        pickerRow.edgeInsets = NSEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
+        pickerRow.translatesAutoresizingMaskIntoConstraints = false
+
+        selectionMoveModifierPickerLabel = primaryLabel(L10n.selectionMoveModifierLabel)
+        pickerRow.addArrangedSubview(selectionMoveModifierPickerLabel)
+        pickerRow.addArrangedSubview(flexSpacer())
+
+        let popup = NSPopUpButton(frame: .zero, pullsDown: false)
+        popup.target = self
+        popup.action = #selector(selectionMoveModifierChanged(_:))
+        popup.controlSize = .small
+        popup.font = NSFont.systemFont(ofSize: 12)
+        selectionMoveModifierPopup = popup
+        pickerRow.addArrangedSubview(popup)
+
+        inner.addArrangedSubview(pickerRow)
+        pickerRow.widthAnchor.constraint(equalTo: inner.widthAnchor).isActive = true
+
+        stack.addArrangedSubview(card)
+        card.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        refreshSelectionMoveModifierPopup()
+        updateSelectionMoveModifierControlsEnabled()
+    }
+
+    private func refreshSelectionMoveModifierPopup() {
+        guard let popup = selectionMoveModifierPopup else { return }
+        popup.removeAllItems()
+        for modifier in SelectionMoveModifier.allCases {
+            popup.addItem(withTitle: modifier.displayName)
+            popup.lastItem?.representedObject = modifier.rawValue
+        }
+        let selected = SelectionMoveModifier.allCases.firstIndex(of: Defaults.selectionMoveModifier) ?? 0
+        popup.selectItem(at: selected)
+        popup.setAccessibilityLabel(L10n.selectionMoveModifierLabel)
+    }
+
+    private func updateSelectionMoveModifierControlsEnabled() {
+        let enabled = Defaults.selectionMoveModifierEnabled
+        selectionMoveModifierPopup?.isEnabled = enabled
+        selectionMoveModifierPopup?.alphaValue = enabled ? 1 : 0.45
+        selectionMoveModifierPickerLabel?.textColor = NSColor.white.withAlphaComponent(enabled ? 0.94 : 0.4)
     }
 
     /// Window-capture shadow card: a toggle for the rounded-corner + drop
@@ -3300,6 +3378,17 @@ class SettingsView: NSView {
         Defaults.pinAcrossSpaces = sender.state == .on
     }
 
+    @objc private func selectionMoveModifierToggled(_ sender: NSSwitch) {
+        Defaults.selectionMoveModifierEnabled = sender.state == .on
+        updateSelectionMoveModifierControlsEnabled()
+    }
+
+    @objc private func selectionMoveModifierChanged(_ sender: NSPopUpButton) {
+        guard let raw = sender.selectedItem?.representedObject as? String,
+              let modifier = SelectionMoveModifier(rawValue: raw) else { return }
+        Defaults.selectionMoveModifier = modifier
+    }
+
     @objc private func menuBarSwitchToggled(_ sender: NSSwitch) {
         let visible = sender.state == .on
         Defaults.showMenuBar = visible
@@ -5213,6 +5302,12 @@ class SettingsView: NSView {
         pinAcrossSpacesTitleLabel?.stringValue = L10n.pinAcrossSpaces
         pinAcrossSpacesSubtitleLabel?.stringValue = L10n.pinAcrossSpacesHint
         pinAcrossSpacesSwitch?.state = Defaults.pinAcrossSpaces ? .on : .off
+        selectionMoveModifierTitleLabel?.stringValue = L10n.selectionMoveModifierToggleLabel
+        selectionMoveModifierHintLabel?.stringValue = L10n.selectionMoveModifierToggleHint
+        selectionMoveModifierPickerLabel?.stringValue = L10n.selectionMoveModifierLabel
+        selectionMoveModifierSwitch?.state = Defaults.selectionMoveModifierEnabled ? .on : .off
+        refreshSelectionMoveModifierPopup()
+        updateSelectionMoveModifierControlsEnabled()
         langTitleLabel?.stringValue = L10n.languageHeader
         filenameRuleCard?.refreshLocalization()
         screenshotQualityTitleLabel?.stringValue = L10n.screenshotQualityTitle

--- a/capcap/Utilities/Defaults.swift
+++ b/capcap/Utilities/Defaults.swift
@@ -1,4 +1,4 @@
-import Foundation
+import AppKit
 
 /// A language the app's UI can be displayed in. Raw values double as the
 /// `appLanguage` UserDefaults value (kept stable for backward compatibility).
@@ -59,6 +59,35 @@ enum AppLanguage: String, CaseIterable {
     }
 }
 
+enum SelectionMoveModifier: String, CaseIterable {
+    case command
+    case option
+    case control
+    case shift
+
+    var displayName: String {
+        switch self {
+        case .command: return L10n.selectionMoveModifierCommand
+        case .option: return L10n.selectionMoveModifierOption
+        case .control: return L10n.selectionMoveModifierControl
+        case .shift: return L10n.selectionMoveModifierShift
+        }
+    }
+
+    private var eventFlag: NSEvent.ModifierFlags {
+        switch self {
+        case .command: return .command
+        case .option: return .option
+        case .control: return .control
+        case .shift: return .shift
+        }
+    }
+
+    func matches(_ flags: NSEvent.ModifierFlags) -> Bool {
+        flags.intersection(.deviceIndependentFlagsMask).contains(eventFlag)
+    }
+}
+
 extension Notification.Name {
     static let languageDidChange = Notification.Name("capcap.languageDidChange")
     static let historyCacheEnabledDidChange = Notification.Name("capcap.historyCacheEnabledDidChange")
@@ -109,6 +138,13 @@ enum L10n {
     static var countdownLabel: String { s("countdownLabel") }
     static var countdownHint: String { s("countdownHint") }
     static var countdownSecondsSuffix: String { s("countdownSecondsSuffix") }
+    static var selectionMoveModifierToggleLabel: String { s("selectionMoveModifierToggleLabel") }
+    static var selectionMoveModifierToggleHint: String { s("selectionMoveModifierToggleHint") }
+    static var selectionMoveModifierLabel: String { s("selectionMoveModifierLabel") }
+    static var selectionMoveModifierCommand: String { s("selectionMoveModifierCommand") }
+    static var selectionMoveModifierOption: String { s("selectionMoveModifierOption") }
+    static var selectionMoveModifierControl: String { s("selectionMoveModifierControl") }
+    static var selectionMoveModifierShift: String { s("selectionMoveModifierShift") }
     static var windowShadowToggleLabel: String { s("windowShadowToggleLabel") }
     static var windowShadowToggleHint: String { s("windowShadowToggleHint") }
     static var windowShadowSizeLabel: String { s("windowShadowSizeLabel") }
@@ -884,6 +920,35 @@ struct Defaults {
 
     static func clearSelectionAspectRatio() {
         defaults.removeObject(forKey: "selectionAspectRatio")
+    }
+
+    static var selectionMoveModifierEnabled: Bool {
+        get {
+            if defaults.object(forKey: "selectionMoveModifierEnabled") == nil {
+                return true
+            }
+            return defaults.bool(forKey: "selectionMoveModifierEnabled")
+        }
+        set {
+            defaults.set(newValue, forKey: "selectionMoveModifierEnabled")
+        }
+    }
+
+    static var selectionMoveModifier: SelectionMoveModifier {
+        get {
+            guard let raw = defaults.string(forKey: "selectionMoveModifier"),
+                  let modifier = SelectionMoveModifier(rawValue: raw) else {
+                return .command
+            }
+            return modifier
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: "selectionMoveModifier")
+        }
+    }
+
+    static func matchesSelectionMoveModifier(_ flags: NSEvent.ModifierFlags) -> Bool {
+        selectionMoveModifierEnabled && selectionMoveModifier.matches(flags)
     }
 
     private static func clearLegacyPinHotkey() {


### PR DESCRIPTION
## Summary

- add a persisted, configurable single-modifier gesture for moving the active selection from anywhere inside it
- prioritize the move gesture over annotations, drawing, and resize handles while preserving existing interactions when inactive
- update the cursor immediately between the normal tool cursor, open hand, and closed hand states
- detect individual visible menu bar components per display while keeping normal application-window targeting unchanged
- crop menu bar component selections from the composited screen snapshot so the visible background is preserved without window shadows or corner effects
- add settings UI, eight localizations, and focused test coverage for both features

## Commits

- `feat(editor): 支持修饰键拖动选区`
- `feat(capture): 支持状态栏组件预选`

## Verification

- `swift build -c debug`
- `git diff --check 52799ab..HEAD`
- manual UI validation was not run, per requester