### PR TITLE
fix(gif): preserve real-time duration for non-multiple source frame rates

### DIFF
--- a/Tests/capcapTests/GIFEncoderFrameTimingTests.swift
+++ b/Tests/capcapTests/GIFEncoderFrameTimingTests.swift
@@ -1,0 +1,97 @@
+import CoreVideo
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+
+@testable import capcap
+
+/// GIF export must preserve the original clip duration when the source frame
+/// rate is not a clean multiple of the GIF target rate. The encoder drops
+/// source frames with an integer `sourceEstimatedFPS / targetFPS` ratio and
+/// then stamps every retained frame with a per-frame delay. That delay must
+/// describe the real span each retained frame represents
+/// (`keepEvery / sourceEstimatedFPS`), not a fixed `1 / targetFPS`, otherwise
+/// a 24fps clip exported to 15fps plays back in slow motion.
+final class GIFEncoderFrameTimingTests: XCTestCase {
+    /// Small solid-color BGRA pixel buffer suitable for feeding the encoder.
+    private func makePixelBuffer(width: Int = 4, height: Int = 4) -> CVPixelBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        let attributes: [CFString: Any] = [
+            kCVPixelBufferCGImageCompatibilityKey: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey: true
+        ]
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width,
+            height,
+            kCVPixelFormatType_32BGRA,
+            attributes as CFDictionary,
+            &pixelBuffer
+        )
+        XCTAssertEqual(status, kCVReturnSuccess, "CVPixelBufferCreate failed")
+        guard let buffer = pixelBuffer else { fatalError("pixelBuffer was nil") }
+
+        CVPixelBufferLockBaseAddress(buffer, .init(rawValue: 0))
+        let baseAddress = CVPixelBufferGetBaseAddress(buffer)
+        let dataSize = CVPixelBufferGetDataSize(buffer)
+        if let baseAddress { memset(baseAddress, 0xFF, dataSize) }
+        CVPixelBufferUnlockBaseAddress(buffer, .init(rawValue: 0))
+        return buffer
+    }
+
+    /// Encodes `frames` frames at `sourceFPS` into a `targetFPS` GIF and returns
+    /// the total playback duration (seconds), summed from the per-frame delay
+    /// ImageIO writes into the finalized file.
+    @discardableResult
+    private func totalDuration(targetFPS: Int, sourceFPS: Int, frames: Int) -> Double {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capcap-gif-timing-\(UUID().uuidString).gif")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let encoder = GIFEncoder(url: url, fps: targetFPS, sourceFPS: sourceFPS)
+        for _ in 0..<frames {
+            encoder.addFrame(makePixelBuffer())
+        }
+        XCTAssertTrue(encoder.finish(), "GIFEncoder failed to finalize the GIF")
+
+        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            XCTFail("Could not open the written GIF at \(url)")
+            return 0
+        }
+
+        var total: Double = 0
+        let frameCount = CGImageSourceGetCount(imageSource)
+        for index in 0..<frameCount {
+            guard
+                let cfProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, index, nil) as? [CFString: Any],
+                let gifDictionary = cfProperties[kCGImagePropertyGIFDictionary] as? [CFString: Any]
+            else { continue }
+            // ImageIO reads these keys back as the kCGImagePropertyGIF...
+            // CFString constants (their on-disk form, e.g. "{GIF}"), so index
+            // with the constants rather than bare Strings. Prefer the clamped
+            // DelayTime; fall back to UnclampedDelayTime if it is absent.
+            let delay = (gifDictionary[kCGImagePropertyGIFDelayTime] as? Double)
+                ?? (gifDictionary[kCGImagePropertyGIFUnclampedDelayTime] as? Double)
+                ?? 0
+            total += delay
+        }
+        return total
+    }
+
+    /// 24fps source exported to a 15fps GIF: sourceFPS sits between target and
+    /// 2*target, so every source frame is retained. The clip must still last
+    /// ~1.0s. Before the fix each retained frame carried a 1/targetFPS delay,
+    /// stretching 24 frames to ~1.6s (slow motion).
+    func testNonMultipleSourceFrameRatePlaysInRealTime() {
+        let total = totalDuration(targetFPS: 15, sourceFPS: 24, frames: 24)
+        XCTAssertEqual(total, 1.0, accuracy: 0.1)
+    }
+
+    /// 30fps -> 15fps divides cleanly (keepEvery = 2). It already plays in real
+    /// time and must continue to do so after the fix — a regression guard that
+    /// is green both before and after the change.
+    func testMultipleSourceFrameRateStaysInRealTime() {
+        let total = totalDuration(targetFPS: 15, sourceFPS: 30, frames: 30)
+        XCTAssertEqual(total, 1.0, accuracy: 0.1)
+    }
+}

--- a/capcap/Capture/GIFEncoder.swift
+++ b/capcap/Capture/GIFEncoder.swift
@@ -8,6 +8,7 @@ final class GIFEncoder {
     private let url: URL
     private let targetFPS: Int
     private let sourceEstimatedFPS: Int
+    private let keepEvery: Int
     private let frameProperties: [CFString: Any]
     private let gifProperties: [CFString: Any]
     private var destination: CGImageDestination?
@@ -19,8 +20,14 @@ final class GIFEncoder {
         self.url = url
         self.targetFPS = min(max(fps, 1), 15)
         self.sourceEstimatedFPS = max(sourceFPS, self.targetFPS)
+        self.keepEvery = max(1, self.sourceEstimatedFPS / self.targetFPS)
 
-        let delayTime = 1.0 / Float(self.targetFPS)
+        // Each retained frame represents `keepEvery` source frames, so its delay
+        // is the span those frames cover (`keepEvery / sourceEstimatedFPS`),
+        // not a flat `1 / targetFPS`. The flat value only holds when the source
+        // rate is a clean multiple of the target; otherwise the GIF plays in slow
+        // motion because every retained frame is stretched to 1/targetFPS.
+        let delayTime = Float(self.keepEvery) / Float(self.sourceEstimatedFPS)
         frameProperties = [
             kCGImagePropertyGIFDictionary: [
                 kCGImagePropertyGIFDelayTime: delayTime,
@@ -49,7 +56,6 @@ final class GIFEncoder {
         defer { lock.unlock() }
 
         inputFrameCount += 1
-        let keepEvery = max(1, sourceEstimatedFPS / targetFPS)
         guard (inputFrameCount - 1) % keepEvery == 0 else { return }
         guard let destination else { return }
 


### PR DESCRIPTION
# fix(gif): preserve real-time duration for non-multiple source frame rates

## Problem

When a recording's frame rate is **not** a clean multiple of the GIF target rate
(default 15 fps), the exported GIF plays back in slow motion. A 24 fps clip
(~1.0 s) exported to a 15 fps GIF comes out at ~1.68 s — roughly 68 % slow. The
same happens for any source rate in the open interval `(target, 2·target)`
(16–29 fps → 15 fps). Sources that divide cleanly (30, 60 fps → 15 fps) are
unaffected.

## Root cause

`capcap/Capture/GIFEncoder.swift` drops source frames with an integer ratio
`keepEvery = max(1, sourceEstimatedFPS / targetFPS)` and then stamps **every
retained frame** with a flat delay of `1 / targetFPS`:

```swift
let delayTime = 1.0 / Float(self.targetFPS)          // init
…
let keepEvery = max(1, sourceEstimatedFPS / targetFPS) // addFrame
guard (inputFrameCount - 1) % keepEvery == 0 else { return }
```

When `target < sourceEstimatedFPS < 2·target`, the integer division floors
`keepEvery` to `1`, so **every** source frame is retained — but each still
carries the `1 / targetFPS` delay instead of the true inter-frame interval
`1 / sourceEstimatedFPS`. For 24 fps → 15 fps that is 24 frames × 1/15 s ≈ 1.6 s
(1.68 s after GIF centisecond rounding), instead of the real 1.0 s.

## Fix

The delay must describe the real time span each retained frame represents,
which is `keepEvery` source frames: `keepEvery / sourceEstimatedFPS`.

- Add a stored `keepEvery` computed once in `init` from the same clamped values
  the frame-skip uses, so the two cannot drift.
- Stamp each retained frame with `Float(keepEvery) / Float(sourceEstimatedFPS)`.
- Reuse the stored `keepEvery` in `addFrame` (drop the local recomputation).

```swift
self.keepEvery = max(1, self.sourceEstimatedFPS / self.targetFPS)
…
let delayTime = Float(self.keepEvery) / Float(self.sourceEstimatedFPS)
```

The new total duration is now `framesFed / sourceEstimatedFPS` regardless of
`keepEvery`, i.e. real time. For clean-multiple sources the delay is numerically
unchanged (`2/30 == 1/15`, `4/60 == 1/15`), so there is **no regression** for
30 fps / 60 fps / 15 fps sources — confirmed by the regression-guard test.

## Verification

```bash
swift test --filter GIFEncoderFrameTimingTests   # 2 passed
swift test                                        # 104 passed (102 baseline + 2 new)
bash scripts/compile-check.sh                     # ✓ No compilation errors
git diff --check                                  # clean
```

New test `Tests/capcapTests/GIFEncoderFrameTimingTests.swift` feeds `GIFEncoder`
real `CVPixelBuffer`s, finalizes a `.gif`, and sums the per-frame `DelayTime`
read back through ImageIO:

- `testNonMultipleSourceFrameRatePlaysInRealTime` — 24 fps source → 15 fps GIF,
  24 frames, asserts total ≈ 1.0 s ± 0.1. **Red before (1.68 s), green after
  (~0.96 s).**
- `testMultipleSourceFrameRateStaysInRealTime` — 30 fps → 15 fps, 30 frames,
  same assertion. Green **before and after** (regression guard).

(Note: ImageIO reads the per-frame GIF sub-dictionary back under the
`kCGImagePropertyGIFDictionary` constant, whose on-disk string form is
`"{GIF}"`; the delay under `kCGImagePropertyGIFDelayTime` (`"DelayTime"`). The
test indexes with the constants directly to stay robust to that quirk.)

## Scope

- Only `GIFEncoder.swift` (delay math) and the new test change.
- The `sourceEstimatedFPS = max(sourceFPS, targetFPS)` clamp and the frame-skip
  modulo logic are intentionally untouched.
- No user-facing strings, localization, Settings, or `Defaults` changes.
