### PR TITLE
fix(capture): round evenDimensions up for odd inputs

### DIFF
--- a/Tests/capcapTests/VideoEncodingSettingsTests.swift
+++ b/Tests/capcapTests/VideoEncodingSettingsTests.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import XCTest
+@testable import capcap
+
+/// `VideoEncodingSettings.evenDimensions` must round odd inputs UP to the next
+/// even integer (H.264 requires even pixel dimensions; rounding down would
+/// capture a frame smaller than the source). These cases pin that contract.
+final class VideoEncodingSettingsTests: XCTestCase {
+
+    // MARK: Odd inputs round up to the next even integer
+
+    func testOddDimensionsRoundUp() {
+        let result = VideoEncodingSettings.evenDimensions(width: 1921, height: 1081)
+        XCTAssertEqual(result.0, 1922, "odd width 1921 must round up to 1922, not down to 1920")
+        XCTAssertEqual(result.1, 1082, "odd height 1081 must round up to 1082, not down to 1080")
+    }
+
+    func testLargeOddDimensionsRoundUp() {
+        let result = VideoEncodingSettings.evenDimensions(width: 3839, height: 2159)
+        XCTAssertEqual(result.0, 3840)
+        XCTAssertEqual(result.1, 2160)
+    }
+
+    // MARK: Even inputs are unchanged
+
+    func testEvenDimensionsAreUnchanged() {
+        let a = VideoEncodingSettings.evenDimensions(width: 1920, height: 1080)
+        XCTAssertEqual(a.0, 1920)
+        XCTAssertEqual(a.1, 1080)
+
+        let b = VideoEncodingSettings.evenDimensions(width: 1922, height: 1082)
+        XCTAssertEqual(b.0, 1922)
+        XCTAssertEqual(b.1, 1082)
+    }
+
+    // MARK: Fractional inputs ceiling up, then round odd up
+
+    func testFractionalCeilsThenRoundsOddUp() {
+        // 1922.5 ceilings to 1923 (odd), which then rounds up to 1924
+        let result = VideoEncodingSettings.evenDimensions(width: 1922.5, height: 1082.5)
+        XCTAssertEqual(result.0, 1924, "1922.5 ceilings to 1923 then rounds up to 1924")
+        XCTAssertEqual(result.1, 1084, "1082.5 ceilings to 1083 then rounds up to 1084")
+    }
+
+    func testFractionalThatCeilsToEvenIsUnchanged() {
+        // 1921.4 ceilings to 1922 (even) and stays; 1079.1 ceilings to 1080 (even) and stays
+        let result = VideoEncodingSettings.evenDimensions(width: 1921.4, height: 1079.1)
+        XCTAssertEqual(result.0, 1922)
+        XCTAssertEqual(result.1, 1080)
+    }
+
+    // MARK: Tiny / sub-minimum inputs honor the 2px floor
+
+    func testTinyOddRoundsUpAboveTwoPixelFloor() {
+        let result = VideoEncodingSettings.evenDimensions(width: 3, height: 3)
+        XCTAssertEqual(result.0, 4, "odd 3 rounds up to 4, above the 2px floor")
+        XCTAssertEqual(result.1, 4)
+    }
+
+    func testMinimumFloorIsTwoPixels() {
+        let one = VideoEncodingSettings.evenDimensions(width: 1, height: 1)
+        XCTAssertEqual(one.0, 2)
+        XCTAssertEqual(one.1, 2)
+
+        let zero = VideoEncodingSettings.evenDimensions(width: 0, height: 0)
+        XCTAssertEqual(zero.0, 2)
+        XCTAssertEqual(zero.1, 2)
+    }
+}

--- a/capcap/Capture/VideoEncodingSettings.swift
+++ b/capcap/Capture/VideoEncodingSettings.swift
@@ -45,8 +45,13 @@ enum VideoEncodingSettings {
     }
 
     static func evenDimensions(width: CGFloat, height: CGFloat) -> (Int, Int) {
-        let w = (Int(width.rounded(.up)) / 2) * 2
-        let h = (Int(height.rounded(.up)) / 2) * 2
+        // Round UP to the next even integer. The naive `(n / 2) * 2` truncates
+        // odd integers back down (1921 -> 1920), defeating `.rounded(.up)` and
+        // capturing a frame one pixel smaller than the source. Adding 1 first
+        // makes odd inputs round up (1921 -> 1922) while even inputs are
+        // unchanged (1920 -> 1920).
+        let w = ((Int(width.rounded(.up)) + 1) / 2) * 2
+        let h = ((Int(height.rounded(.up)) + 1) / 2) * 2
         return (max(w, 2), max(h, 2))
     }
 


### PR DESCRIPTION
fix(capture): round evenDimensions up for odd inputs

## Summary

`VideoEncodingSettings.evenDimensions` was rounding odd inputs **down** instead of up,
capturing recordings one pixel undersized per axis whenever the source had an odd point
dimension at 1× scale (e.g. an external display with `backingScaleFactor == 1`). This makes
odd inputs round up to the next even integer, matching the function's name and its existing
`.rounded(.up)`.

## Why

H.264 encoding (`AVVideoWidthKey` / `AVVideoHeightKey`) requires even pixel dimensions, so
`evenDimensions` exists to coerce a capture size to even. The original expression was

```swift
let w = (Int(width.rounded(.up)) / 2) * 2
```

`.rounded(.up)` ceilings to an integer, but the integer `(/ 2) * 2` then truncates back down
to the nearest even value **≤** it. For an odd integer the two cancel and the result rounds
**down** — the opposite of what `.rounded(.up)` clearly intended:

```
1921 -> .rounded(.up) -> 1921 -> 1921 / 2 -> 960 -> 960 * 2 -> 1920   (one BELOW the input)
```

The single call site is `RecordingEngine.swift:463-467`:

```swift
let scale = max(screen.backingScaleFactor, 1)
let (pixelWidth, pixelHeight) = VideoEncodingSettings.evenDimensions(
    width: sourceRect.width * scale,
    height: sourceRect.height * scale
)
```

With `scale == 1` (external display) and an odd `sourceRect` dimension, e.g. `1921`, the
recording comes out `1920` — 1 px smaller than the source on each affected axis. Even inputs
were unaffected.

## Changes

- `capcap/Capture/VideoEncodingSettings.swift` — round up to the next even integer instead of
  truncating down:
  ```swift
  let w = ((Int(width.rounded(.up)) + 1) / 2) * 2
  let h = ((Int(height.rounded(.up)) + 1) / 2) * 2
  ```
  Odd inputs round up (`1921 -> 1922`); even inputs are unchanged (`1920 -> 1920`,
  `1922 -> 1922`). The existing `max(_, 2)` tiny-input floor is left untouched.
- `Tests/capcapTests/VideoEncodingSettingsTests.swift` — new pure-value regression suite
  (7 tests) covering odd round-up, even unchanged, fractional ceiling then round-up, the 2 px
  floor, and minimum/zero inputs.

## Verification

```sh
git diff --check
swift test --filter VideoEncodingSettingsTests     # 7 tests, 0 failures
swift build                                         # Build complete
swift test                                          # 109 tests, 0 failures
bash scripts/compile-check.sh                       # ✓ No compilation errors found
```

The new suite was confirmed **RED before the fix** (`1921 -> 1920`, 8 failures across the
odd/ceil-odd cases) and **GREEN after**, so the test actually exercises the fixed path.

No user-facing strings, no other capture paths touched (`RecordingEngine`, `GIFEncoder`
unchanged).
