### PR TITLE
fix(editor): 拖动马赛克时按新位置重新打码

### DIFF
--- a/Tests/capcapTests/MosaicAnnotationTranslationTests.swift
+++ b/Tests/capcapTests/MosaicAnnotationTranslationTests.swift
@@ -1,0 +1,103 @@
+import AppKit
+import XCTest
+@testable import capcap
+
+@MainActor
+final class MosaicAnnotationTranslationTests: XCTestCase {
+    func testDraggingMosaicRepixelatesAtDestination() throws {
+        let canvas = EditCanvasView(frame: NSRect(x: 0, y: 0, width: 100, height: 100))
+        canvas.overrideBaseImage = try makeHalfRedHalfBlueImage()
+        canvas.currentMosaicBlockSize = 8
+        canvas.activeTool = .mosaic
+
+        // Draw a mosaic over the red half.
+        canvas.mouseDown(with: try mouseEvent(type: .leftMouseDown, point: NSPoint(x: 10, y: 40)))
+        canvas.mouseDragged(with: try mouseEvent(type: .leftMouseDragged, point: NSPoint(x: 40, y: 70)))
+        canvas.mouseUp(with: try mouseEvent(type: .leftMouseUp, point: NSPoint(x: 40, y: 70)))
+
+        XCTAssertTrue(canvas.selectAllAnnotations())
+        let original = try XCTUnwrap(canvas.selectedAnnotation as? MosaicAnnotation)
+        let originalRed = try XCTUnwrap(centerColor(of: original.pixelatedImage))
+        XCTAssertGreaterThan(originalRed.redComponent, 0.6)
+        XCTAssertLessThan(originalRed.blueComponent, 0.4)
+
+        // Drag the frame to the blue half. The frame itself should decide
+        // what gets pixelated, so the moved mosaic must sample blue pixels
+        // instead of carrying the red texture along.
+        let start = NSPoint(x: original.rect.midX, y: original.rect.midY)
+        let delta = NSPoint(x: 50, y: 0)
+        canvas.mouseDown(with: try mouseEvent(type: .leftMouseDown, point: start))
+        canvas.mouseDragged(with: try mouseEvent(
+            type: .leftMouseDragged,
+            point: NSPoint(x: start.x + delta.x, y: start.y + delta.y)
+        ))
+        canvas.mouseUp(with: try mouseEvent(
+            type: .leftMouseUp,
+            point: NSPoint(x: start.x + delta.x, y: start.y + delta.y)
+        ))
+
+        let moved = try XCTUnwrap(canvas.selectedAnnotation as? MosaicAnnotation)
+        XCTAssertEqual(moved.rect.minX, original.rect.minX + delta.x, accuracy: 0.001)
+        let movedColor = try XCTUnwrap(centerColor(of: moved.pixelatedImage))
+        XCTAssertGreaterThan(movedColor.blueComponent, 0.6)
+        XCTAssertLessThan(movedColor.redComponent, 0.4)
+    }
+
+    private func centerColor(of image: NSImage) -> NSColor? {
+        guard
+            let rep = image.bitmapImageRepPreservingBacking(),
+            rep.pixelsWide > 0,
+            rep.pixelsHigh > 0
+        else {
+            return nil
+        }
+        return rep.colorAt(x: rep.pixelsWide / 2, y: rep.pixelsHigh / 2)?
+            .usingColorSpace(.deviceRGB)
+    }
+
+    private func makeHalfRedHalfBlueImage() throws -> NSImage {
+        let width = 100
+        let height = 100
+        let rep = try XCTUnwrap(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ))
+        rep.size = NSSize(width: width, height: height)
+
+        let graphicsContext = try XCTUnwrap(NSGraphicsContext(bitmapImageRep: rep))
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = graphicsContext
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: width / 2, height: height).fill()
+        NSColor.blue.setFill()
+        NSRect(x: width / 2, y: 0, width: width / 2, height: height).fill()
+        graphicsContext.flushGraphics()
+        NSGraphicsContext.restoreGraphicsState()
+
+        let image = NSImage(size: rep.size)
+        image.addRepresentation(rep)
+        return image
+    }
+
+    private func mouseEvent(type: NSEvent.EventType, point: NSPoint) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.mouseEvent(
+            with: type,
+            location: point,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+}

--- a/capcap/Editor/EditCanvasView.swift
+++ b/capcap/Editor/EditCanvasView.swift
@@ -274,7 +274,33 @@ class EditCanvasView: NSView {
         if let text = annotation as? TextAnnotation {
             return text.translatedBodyPreservingCalloutTip(by: delta)
         }
+        if let mosaic = annotation as? MosaicAnnotation {
+            return translatedMosaic(mosaic, by: delta)
+        }
         return annotation.translated(by: delta)
+    }
+
+    /// Move a mosaic by re-pixelating the underlying image at the new frame
+    /// position. The mosaic is an edited region of the screenshot, not a
+    /// movable texture, so the frame itself decides what gets pixelated.
+    private func translatedMosaic(_ mosaic: MosaicAnnotation, by delta: NSPoint) -> Annotation {
+        let newRect = mosaic.rect.offsetBy(dx: delta.x, dy: delta.y)
+        guard
+            let baseImage = resolveBaseImageForEditing(),
+            let region = MosaicTool.createMosaicRegion(
+                rect: newRect,
+                imageSize: bounds.size,
+                baseImage: baseImage,
+                blockSize: mosaic.blockSize
+            )
+        else {
+            return mosaic.translated(by: delta)
+        }
+        return MosaicAnnotation(
+            rect: region.rect,
+            pixelatedImage: region.pixelatedImage,
+            blockSize: mosaic.blockSize
+        )
     }
 
     private struct PendingTextCreate {
@@ -629,7 +655,12 @@ class EditCanvasView: NSView {
         }
         recordUndo()
         for idx in indexes {
-            annotations[idx] = annotations[idx].translated(by: delta)
+            let annotation = annotations[idx]
+            if let mosaic = annotation as? MosaicAnnotation {
+                annotations[idx] = translatedMosaic(mosaic, by: delta)
+            } else {
+                annotations[idx] = annotation.translated(by: delta)
+            }
         }
         needsDisplay = true
         refreshCursorAtCurrentLocation()
@@ -685,7 +716,12 @@ class EditCanvasView: NSView {
             return false
         }
         let offset = pasteOffset(forPasting: sources)
-        let pasted = sources.map { $0.translated(by: offset) }
+        let pasted = sources.map { source in
+            if let mosaic = source as? MosaicAnnotation {
+                return translatedMosaic(mosaic, by: offset)
+            }
+            return source.translated(by: offset)
+        }
         let firstNewIndex = annotations.count
         recordUndo()
         annotations.append(contentsOf: pasted)


### PR DESCRIPTION
· 修复拖动马赛克框时旧贴图整体移动的问题，改为按框的新位置从原图重新打码
· 方向键微调与粘贴马赛克同样按新位置重新打码

Befor：

https://github.com/user-attachments/assets/0c0c5ee9-6444-43ab-a5e9-3f22738a1437

After：

https://github.com/user-attachments/assets/3466d182-9ed8-4aec-bb8c-4f8b363e436f

