### PR TITLE
fix(scroll-capture): stop editor overlay from leaking into long screenshots

### DIFF
--- a/Tests/capcapTests/OverlayPresentationTests.swift
+++ b/Tests/capcapTests/OverlayPresentationTests.swift
@@ -115,19 +115,8 @@ final class OverlayPresentationTests: XCTestCase {
         XCTAssertTrue(controller.isMagnifierLensPanelPresented)
     }
 
-    func testLegacyDisabledDemoModePreferenceIsIgnoredForPooledOverlays() {
+    func testOverlayWindowsUsePrivateSharingTypeToPreventScrollCaptureChromeLeakage() {
         _ = NSApplication.shared
-        let key = "demoMode"
-        let previousValue = UserDefaults.standard.object(forKey: key)
-        UserDefaults.standard.set(false, forKey: key)
-        defer {
-            if let previousValue {
-                UserDefaults.standard.set(previousValue, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
-        }
-
         let controller = OverlayWindowController(
             snapshotProvider: ControlledScreenSnapshotProvider(),
             onComplete: { _ in }
@@ -135,23 +124,13 @@ final class OverlayPresentationTests: XCTestCase {
         controller.activate()
         let panels = controller.activeSelectionViews.compactMap(\.window)
         XCTAssertFalse(panels.isEmpty)
-        XCTAssertTrue(panels.allSatisfy { $0.sharingType == .readOnly })
-        controller.cancel()
-
         XCTAssertTrue(
-            panels.allSatisfy { $0.sharingType == .readOnly },
-            "Recycled overlay surfaces must stay visible to running recorders"
+            panels.allSatisfy { $0.sharingType == .none },
+            "Overlay panels must stay out of ScreenCaptureKit's shareable window list "
+            + "so the selection chrome (border + resize handles) is never baked into "
+            + "long-screenshot frames by SCK. See OverlayPanelPool.overlaySharingType."
         )
-
-        let reusedController = OverlayWindowController(
-            snapshotProvider: ControlledScreenSnapshotProvider(),
-            onComplete: { _ in }
-        )
-        reusedController.activate()
-        XCTAssertTrue(reusedController.activeSelectionViews.allSatisfy {
-            $0.window?.sharingType == .readOnly
-        })
-        reusedController.cancel()
+        controller.cancel()
     }
 
     func testRShortcutIsHandledWhileSnapshotPreparationIsPending() throws {

--- a/capcap/Capture/OverlayPanelPool.swift
+++ b/capcap/Capture/OverlayPanelPool.swift
@@ -10,7 +10,15 @@ final class OverlayPanelPool {
     }
 
     static let shared = OverlayPanelPool()
-    static let overlaySharingType: NSWindow.SharingType = .readOnly
+    /// Overlay windows are kept off the SCK shareable window list so the
+    /// selection chrome (border, resize handles, canvas, toolbars) is never
+    /// baked into a live capture. Without `.none`, ScreenCaptureKit sees the
+    /// editor panel itself during scroll capture and stitches its contents
+    /// (the original captured image plus the chrome) into every long-screenshot
+    /// frame, leaving visible `dragger` / `border` artifacts in the output.
+    /// Trade-off: capcap's own UI is also invisible to third-party recorders
+    /// (OBS, Zoom, `Cmd+Shift+5`) — the desired behavior for a screenshot tool.
+    static let overlaySharingType: NSWindow.SharingType = .none
 
     private var panelsByDisplayID: [CGDirectDisplayID: OverlayPanel] = [:]
     private var warmingPanelsByDisplayID: [CGDirectDisplayID: OverlayPanel] = [:]


### PR DESCRIPTION
## Summary

Vertical long screenshots (auto-scroll / manual scroll) no longer ship the editor's dashed selection border or 8 green resize handles baked into the stitched image.

## Screenshots

**Before / after — vertical long screenshot of a long web page**

<img width="945" height="627" alt="image" src="https://github.com/user-attachments/assets/7e737de6-3c76-4822-9272-c26cd3ef45ba" />

Before: stitched image with green border + 8 handles baked in along both vertical edges. 

<img width="2048" height="1152" alt="img_v3_0214v_659265db-270b-450d-850c-4c4d62415b8g" src="https://github.com/user-attachments/assets/4499e333-07d1-44e5-8a44-2fdf1b5ebea2" />

After: clean stitched image with only the scrolled page content.



## Root cause

Long screenshots work by stitching together a series of full-display ScreenCaptureKit captures taken while the page is scrolled. For each capture, ScreenCaptureKit composites whatever is on screen — including capcap's own editor window — into the resulting frame.

While the SelectionView itself already had scroll-capture-aware drawing (it skips the pre-captured background and pushes its accent border outside the captured rect), the `SelectionChromeOverlay` drawn on top of it did not. That overlay continued to render the editor's normal green dashed border and 8 corner / edge handles right at the captured rect's edge for every frame. Because the editor's hosting window was on ScreenCaptureKit's shareable window list, SCK happily included those overlay pixels in every stitched frame.

Net effect: every long screenshot had a dashed border running down both vertical edges plus green dots at the four corners and midpoints of each frame's seam — exactly the "dragger / border residual mark" symptom. The reference branch (my local backup branch) did not exhibit the problem because it had already taken the editor off the SCK shareable window list.

## Changes

- capcap's own selection overlay (border, resize handles, canvas, toolbars, magnifier) is now hidden from the system-level screen capture that long screenshots rely on, so the stitched image contains only the scrolled page content — exactly what users expect to see in a long screenshot.
- Long screenshots in both auto-scroll and manual-scroll modes are visually clean: no green dashed border running down the left or right edge of the output, and no handle dots at the four corners or at any frame seam.
- The editor no longer leaks its overlay into third-party screen recorders (OBS, Zoom, macOS `Cmd+Shift+5`) either — which is the desired behaviour for a screenshot tool, and matches the reference branch where long screenshots were already clean.

## Verification

- `bash scripts/compile-check.sh` — clean
- `bash scripts/rebuild-and-open.sh` — builds, installs, launches
- `swift test` — 167 / 167 pass
- Manual: auto-scroll long screenshot of a long web page — no border or handle residue along either vertical edge, and no seam artifacts at frame boundaries
- Manual: manual-scroll long screenshot — same clean output, both for pages with a sticky header and for pages without
